### PR TITLE
docs: Add Claude Code configuration and project guide

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -1,0 +1,257 @@
+---
+name: code-reviewer
+description: Local code review enforcing fmpsdk SDK standards
+tools: Read, Grep, Bash
+---
+
+# Code Reviewer Agent - fmpsdk
+
+You are a code reviewer for the fmpsdk Python SDK. Your job is to ensure consistency, proper patterns, and code quality for this Financial Modeling Prep API wrapper.
+
+## Review Process
+
+1. Read the file content provided
+2. Check against ALL patterns below
+3. Output a structured review summary
+
+---
+
+## BLOCK-Level Checks (Must Fail Review)
+
+These issues MUST be fixed before committing.
+
+### 1. Missing API Key Usage
+
+**Pattern to catch:** Functions that make API calls without using `API_KEY` variable
+
+```python
+# BLOCK: Hardcoded or missing API key
+query_vars = {"apikey": "your_key_here", ...}
+query_vars = {"limit": limit}  # Missing apikey
+
+# PASS: Uses environment variable
+API_KEY = os.getenv('FMP_API_KEY')
+query_vars = {"apikey": API_KEY, ...}
+```
+
+### 2. Wrong API Version
+
+**Pattern to catch:** Using v3 endpoint function for v4 API or vice versa
+
+```python
+# BLOCK: Using wrong version (check FMP docs for correct version)
+# v4 endpoints called with __return_json_v3
+result = __return_json_v3(path="company-core-information", ...)  # This is v4!
+
+# PASS: Correct version matching endpoint
+result = __return_json_v4(path="company-core-information", ...)  # v4 endpoint
+result = __return_json_v3(path="profile/AAPL", ...)  # v3 endpoint
+```
+
+### 3. Missing format_output Call
+
+**Pattern to catch:** Functions returning raw JSON without format_output wrapper
+
+```python
+# BLOCK: Raw return without formatting
+def my_function(symbol: str, output: str = 'markdown'):
+    result = __return_json_v3(path=path, query_vars=query_vars)
+    return result  # Missing format_output!
+
+# PASS: Proper formatting
+def my_function(symbol: str, output: str = 'markdown'):
+    result = __return_json_v3(path=path, query_vars=query_vars)
+    return format_output(result, output)
+```
+
+### 4. Missing __init__.py Export
+
+**Pattern to catch:** New public functions not added to `__init__.py` imports and `__all__`
+
+```python
+# BLOCK: Function exists in module but not exported
+# In fmpsdk/some_module.py:
+def new_public_function(symbol: str) -> typing.List:
+    ...
+
+# But missing from fmpsdk/__init__.py imports and __all__ list
+
+# PASS: Properly exported
+# In fmpsdk/__init__.py:
+from .some_module import new_public_function
+__all__ = [..., "new_public_function", ...]
+```
+
+### 5. Inconsistent Function Signature
+
+**Pattern to catch:** Functions that don't follow the standard signature pattern
+
+```python
+# BLOCK: Non-standard parameter order or naming
+def my_function(period: str, symbol: str, limit: int):  # Wrong order
+def my_function(sym: str, output: str = 'json'):  # Wrong param name, wrong default
+
+# PASS: Standard pattern
+def my_function(
+    symbol: str,                    # First: required symbol
+    period: str = "annual",         # Optional: period
+    limit: int = DEFAULT_LIMIT,     # Optional: limit (use constant)
+    output: str = 'markdown'        # Last: output format, default markdown
+) -> typing.Union[typing.List[typing.Dict], str]:
+```
+
+### 6. Missing Type Hints
+
+**Pattern to catch:** Public functions without proper type annotations
+
+```python
+# BLOCK: No type hints
+def company_profile(symbol):
+    ...
+
+# PASS: Full type hints
+def company_profile(
+    symbol: str,
+    output: str = 'markdown'
+) -> typing.Union[typing.List[typing.Dict], str]:
+```
+
+### 7. File Write Without Context Manager
+
+**Pattern to catch:** Open file writes without proper handling
+
+```python
+# BLOCK: No context manager
+open(filename, "wb").write(response.content)
+
+# PASS: Using context manager
+with open(filename, "wb") as f:
+    f.write(response.content)
+```
+
+---
+
+## WARN-Level Checks (Should Fix, Non-Blocking)
+
+These issues should be fixed but won't block the review.
+
+### W1. Missing Docstring
+
+**Pattern:** Public functions without docstrings
+
+```python
+# WARN: No docstring
+def company_profile(symbol: str) -> typing.List:
+    path = f"profile/{symbol}"
+    ...
+
+# BETTER: Has docstring
+def company_profile(symbol: str) -> typing.List:
+    """
+    Retrieve a comprehensive overview of a company.
+
+    :param symbol: Ticker symbol of the company (e.g., 'AAPL').
+    :param output: Output format ('tsv', 'json', or 'markdown').
+    :return: Company profile data in the specified format.
+    :example: company_profile('AAPL', output='markdown')
+    """
+```
+
+### W2. Missing Example in Docstring
+
+**Pattern:** Docstring without `:example:` tag
+
+### W3. Hardcoded Limit Value
+
+**Pattern:** Using numeric literals instead of DEFAULT_LIMIT constant
+
+```python
+# WARN: Hardcoded default
+def my_function(symbol: str, limit: int = 10):
+
+# BETTER: Use constant
+def my_function(symbol: str, limit: int = DEFAULT_LIMIT):
+```
+
+### W4. Missing Period Validation
+
+**Pattern:** Functions accepting period parameter without validation
+
+```python
+# WARN: No validation
+query_vars = {"period": period}
+
+# BETTER: Validate period
+query_vars = {"period": __validate_period(period)}
+```
+
+### W5. Broad Exception Handling
+
+**Pattern:** Catching generic Exception without specific handling
+
+```python
+# WARN: Too broad
+except Exception as e:
+    logging.error(f"Error: {e}")
+
+# BETTER: Specific exceptions
+except requests.Timeout:
+    logging.error("Request timed out")
+except requests.ConnectionError:
+    logging.error("Connection failed")
+```
+
+### W6. Missing Logging for Errors
+
+**Pattern:** Error conditions that don't log anything
+
+---
+
+## Output Format
+
+```markdown
+## Review Summary: [PASS | BLOCK | WARN]
+
+### BLOCK Issues (must fix before commit)
+- `file.py:42` - [Issue Type]: Description
+  ```python
+  # Current code
+  problematic code here
+
+  # Suggested fix
+  corrected code here
+  ```
+
+### WARN Issues (should fix)
+- `file.py:89` - [Issue Type]: Description
+  Brief explanation of the issue
+
+### Files Reviewed
+- fmpsdk/module.py [PASS | BLOCK(n) | WARN(n)]
+
+### Statistics
+- Total files: X
+- BLOCK issues: Y
+- WARN issues: Z
+```
+
+---
+
+## Review Instructions
+
+When reviewing a file:
+
+1. **Read the entire file** to understand context
+2. **Check each BLOCK pattern** - these are hard failures
+3. **Check each WARN pattern** - note but don't fail
+4. **Verify __init__.py** - new functions must be exported
+5. **Be specific** - include line numbers and exact code snippets
+6. **Provide fixes** - show the corrected code for each issue
+
+## SDK-Specific Considerations
+
+- All public functions should support `output` parameter with 'markdown' default
+- Use `typing.Union[typing.List[typing.Dict], str]` for functions with output param
+- Import validators from `url_methods.py`, not reimplementing
+- Use `format_output` from `data_compression.py` for output formatting
+- Environment variable `FMP_API_KEY` should be used, never hardcoded keys

--- a/.claude/commands/fix-review.md
+++ b/.claude/commands/fix-review.md
@@ -1,0 +1,146 @@
+# Fix Review Issues Command
+
+Automatically fix issues found by `/review-staged`.
+
+**Goal:** Quickly resolve common issues identified during code review.
+
+## Process
+
+### Step 1: Re-run Review
+
+First, identify current issues:
+```bash
+/review-staged
+```
+
+### Step 2: Auto-fixable Issues
+
+For each BLOCK issue, apply the fix:
+
+#### Missing format_output
+Add the format_output wrapper:
+```python
+# Before
+return result
+
+# After
+return format_output(result, output)
+```
+
+#### Missing __init__.py Export
+Add import and __all__ entry:
+```python
+# In fmpsdk/__init__.py, add:
+from .module_name import function_name
+
+# In __all__ list, add:
+"function_name",
+```
+
+#### Missing Type Hints
+Add standard type hints:
+```python
+# Before
+def my_function(symbol, period="annual", limit=10):
+
+# After
+def my_function(
+    symbol: str,
+    period: str = "annual",
+    limit: int = DEFAULT_LIMIT,
+    output: str = 'markdown'
+) -> typing.Union[typing.List[typing.Dict], str]:
+```
+
+#### Hardcoded Limit
+Replace with constant:
+```python
+# Before
+limit: int = 10
+
+# After
+limit: int = DEFAULT_LIMIT
+```
+
+#### Missing Period Validation
+Add validation call:
+```python
+# Before
+query_vars = {"period": period}
+
+# After
+query_vars = {"period": __validate_period(period)}
+```
+
+### Step 3: Manual Fixes Required
+
+Some issues require manual intervention:
+
+- **Wrong API version**: Verify against FMP API docs which version to use
+- **Missing docstring**: Write meaningful documentation
+- **Broad exception handling**: Determine specific exceptions to catch
+
+### Step 4: Verify Fixes
+
+After applying fixes:
+```bash
+/review-staged
+```
+
+Confirm all BLOCK issues are resolved.
+
+## Usage
+
+```bash
+# Run after /review-staged shows issues
+/fix-review
+
+# Or fix specific file
+/fix-review fmpsdk/financial_statements.py
+```
+
+## Quick Fix Templates
+
+### Standard Function Template
+```python
+def function_name(
+    symbol: str,
+    period: str = "annual",
+    limit: int = DEFAULT_LIMIT,
+    output: str = 'markdown'
+) -> typing.Union[typing.List[typing.Dict], str]:
+    """
+    Brief description of what this function does.
+
+    :param symbol: Company ticker (e.g., 'AAPL').
+    :param period: 'quarter' or 'annual'. Default is 'annual'.
+    :param limit: Number of records to retrieve. Default is DEFAULT_LIMIT.
+    :param output: Output format ('tsv', 'json', or 'markdown'). Defaults to 'markdown'.
+    :return: Data in the specified format.
+    :example: function_name('AAPL', period='quarter', limit=5)
+    """
+    path = f"endpoint-path/{symbol}"
+    query_vars = {
+        "apikey": API_KEY,
+        "period": __validate_period(period),
+        "limit": limit,
+    }
+    result = __return_json_v3(path=path, query_vars=query_vars)
+    return format_output(result, output)
+```
+
+### Required Imports for New Modules
+```python
+import typing
+import os
+
+from .settings import DEFAULT_LIMIT
+from .url_methods import (
+    __return_json_v3,
+    __return_json_v4,
+    __validate_period,
+)
+from .data_compression import format_output
+
+API_KEY = os.getenv('FMP_API_KEY')
+```

--- a/.claude/commands/review-staged.md
+++ b/.claude/commands/review-staged.md
@@ -1,0 +1,138 @@
+# Pre-Push Review Command
+
+Review all staged and unstaged changes against fmpsdk SDK coding standards.
+
+**Goal:** Ensure consistency and quality in the fmpsdk Python SDK before committing.
+
+## Process
+
+### Step 1: Identify Changed Files
+
+Run these commands to get all changed files:
+
+```bash
+# Get all changed files (staged and unstaged)
+git diff --name-only HEAD
+git diff --cached --name-only
+```
+
+### Step 2: Categorize Changes
+
+Focus on Python files in `fmpsdk/` directory:
+- **SDK modules:** `fmpsdk/*.py`
+- **Root files:** `*.py` (example files, MCP server)
+- **Config:** `pyproject.toml`
+
+### Step 3: Run Automated Checks
+
+**Linting (if available):**
+```bash
+poetry run black --check fmpsdk/
+poetry run isort --check fmpsdk/
+poetry run flake8 fmpsdk/
+```
+
+**Type checking (if available):**
+```bash
+poetry run mypy fmpsdk/
+```
+
+Note: These may not be configured yet - skip if not available.
+
+### Step 4: Verify __init__.py Consistency
+
+For any new functions added to modules:
+
+1. Check if function is imported in `fmpsdk/__init__.py`
+2. Check if function is listed in `__all__`
+
+```bash
+# List all public functions (def without leading underscore)
+grep "^def [^_]" fmpsdk/*.py
+
+# Check __all__ list
+grep -A 200 "^__all__" fmpsdk/__init__.py
+```
+
+### Step 5: Run Code Review Agent
+
+For each changed `.py` file in `fmpsdk/`:
+
+1. Read the file content
+2. Get the diff: `git diff HEAD -- <filepath>`
+3. Apply all BLOCK and WARN checks from `.claude/agents/code-reviewer.md`
+4. Collect all issues
+
+### Step 6: Generate Summary
+
+Output format:
+
+```markdown
+## Pre-Push Review: [READY | BLOCKED]
+
+### Automated Checks
+- Black format: [PASS | FAIL | SKIPPED]
+- Isort imports: [PASS | FAIL | SKIPPED]
+- Flake8 lint: [PASS | FAIL | SKIPPED]
+- Mypy types: [PASS | FAIL | SKIPPED]
+
+### Export Consistency
+- New functions exported: [YES | NO | N/A]
+- __all__ list updated: [YES | NO | N/A]
+
+### Code Review
+- Files reviewed: X
+- BLOCK issues: Y
+- WARN issues: Z
+
+### BLOCK Issues (must fix)
+[List each with file:line and fix]
+
+### WARN Issues (consider fixing)
+[List each with file:line and explanation]
+
+### Files Reviewed
+- fmpsdk/module.py [status]
+
+### Recommendation
+[READY TO PUSH] or [FIX REQUIRED: list blocking issues]
+```
+
+## Arguments
+
+- `$ARGUMENTS` (optional): Specific file or directory to review
+  - If omitted, review all uncommitted changes
+  - Can be a file path: `fmpsdk/financial_statements.py`
+  - Can be a directory: `fmpsdk/`
+
+## Usage Examples
+
+```bash
+# Review all uncommitted changes
+/review-staged
+
+# Review specific file
+/review-staged fmpsdk/financial_statements.py
+
+# Review all SDK modules
+/review-staged fmpsdk/
+```
+
+## Quick Reference: What Gets Checked
+
+### Python BLOCK Checks
+1. Missing API_KEY usage from environment
+2. Wrong API version (v3 vs v4) for endpoint
+3. Missing format_output call for output parameter
+4. New function not exported in __init__.py
+5. Inconsistent function signature pattern
+6. Missing type hints on public functions
+7. File writes without context manager
+
+### Python WARN Checks
+1. Missing docstring
+2. Missing :example: in docstring
+3. Hardcoded limit instead of DEFAULT_LIMIT
+4. Missing period validation
+5. Broad exception handling
+6. Missing error logging

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,253 @@
+# fmpsdk Development Guide
+
+## Overview
+
+This is a **forked and customized** Python SDK for the [Financial Modeling Prep (FMP) API](https://financialmodelingprep.com). The original SDK was created by Dax Mickelson; this fork is maintained by David Rodriguez with substantial modifications for LLM integration and GenAI.Financial use cases.
+
+**Key Differences from Original:**
+- Default output format changed from JSON to **Markdown tables** (LLM-friendly)
+- Added data compression utilities for efficient LLM consumption
+- Custom `sec_filings_data()` function that fetches and parses actual SEC filing content
+- MCP (Model Context Protocol) server integration
+- Precision control for numeric values
+
+## Project Structure
+
+```
+fmpsdk/
+├── __init__.py          # Root package (re-exports fmpsdk/)
+├── fmpsdk/              # Main SDK package
+│   ├── __init__.py      # Exports 159 public functions
+│   ├── url_methods.py   # Core HTTP methods (__return_json_v3, __return_json_v4)
+│   ├── settings.py      # Constants (BASE_URLs, valid values, filenames)
+│   ├── data_compression.py  # Output formatting (TSV, Markdown, JSON)
+│   │
+│   ├── # Financial Data Modules
+│   ├── financial_statements.py   # Income, balance sheet, cash flow, SEC filings
+│   ├── company_profile.py        # Company info, executives, metrics
+│   ├── company_valuation.py      # Ratings, peers, analysts, ESG
+│   ├── financial_growth_ratios.py # Growth metrics, ratios
+│   ├── valuation_metrics.py      # DCF, market cap
+│   │
+│   ├── # Market Data Modules
+│   ├── quote.py                  # Real-time quotes, forex, crypto
+│   ├── stock_time_series.py      # Historical prices, dividends, splits
+│   ├── stock_market.py           # Gainers, losers, sectors
+│   ├── market_indexes.py         # S&P 500, NASDAQ, Dow Jones constituents
+│   ├── technical_indicators.py   # SMA, EMA, RSI, etc.
+│   │
+│   ├── # Alternative Data Modules
+│   ├── news.py                   # Stock news, press releases
+│   ├── calendar_data.py          # Earnings, dividends, IPO calendars
+│   ├── insider_trading.py        # Insider transactions
+│   ├── institutional_fund.py     # 13F filings, ETF holdings
+│   ├── senate.py                 # Senate trading disclosures
+│   ├── social_sentiment.py       # Social media sentiment
+│   │
+│   ├── # Reference Data Modules
+│   ├── available_data.py         # Symbol lists, exchanges, sectors
+│   ├── search_functions.py       # Ticker/company search
+│   └── ...
+│
+├── fmpsdk_mcp_server.py  # MCP server for Claude Desktop
+├── example_usage.py      # Usage examples
+├── pyproject.toml        # Poetry config (Python 3.12+)
+└── README.md
+```
+
+## Environment Variables
+
+```bash
+FMP_API_KEY=your_fmp_api_key        # Required - get from financialmodelingprep.com
+SEC_USER_AGENT=your_email@domain    # Required for SEC filing downloads
+```
+
+## Code Patterns
+
+### Function Signature Pattern
+
+All public functions follow this pattern:
+
+```python
+def function_name(
+    symbol: str,                           # Usually required
+    period: str = "annual",                # "annual" or "quarter"
+    limit: int = DEFAULT_LIMIT,            # Default is 10
+    output: str = 'markdown',              # 'markdown', 'tsv', or 'json'
+    precision: typing.Optional[int] = 5    # Decimal places (some functions)
+) -> typing.Union[typing.List[typing.Dict], str]:
+```
+
+### Output Formats
+
+```python
+# Markdown (default) - best for LLM consumption
+fmpsdk.income_statement('AAPL', output='markdown')
+# Returns: "| date | revenue | netIncome | ... |\n|---|---|---| ..."
+
+# JSON - best for programmatic access
+fmpsdk.income_statement('AAPL', output='json')
+# Returns: [{"date": "2024-09-28", "revenue": 391035000000, ...}, ...]
+
+# TSV - compact tabular format
+fmpsdk.income_statement('AAPL', output='tsv')
+# Returns: "date\trevenue\tnetIncome\n2024-09-28\t391035000000\t..."
+```
+
+### API Version Routing
+
+- **v3 API** (`__return_json_v3`): Most endpoints - financial statements, quotes, company data
+- **v4 API** (`__return_json_v4`): Newer endpoints - batch transcripts, core info, outlook
+
+### Error Handling
+
+Functions return `None` on API errors (logged to console). Check return values:
+
+```python
+result = fmpsdk.company_profile('AAPL')
+if result is None:
+    # Handle error - check logs for details
+```
+
+## Key Functions for Case Studies
+
+### Financial Statements
+```python
+fmpsdk.income_statement(symbol, period='annual', limit=10)
+fmpsdk.balance_sheet_statement(symbol, period='annual', limit=10)
+fmpsdk.cash_flow_statement(symbol, period='annual', limit=10)
+```
+
+### SEC Filings (Custom Enhancement)
+```python
+# Get filing metadata (links only)
+fmpsdk.sec_filings(symbol, filing_type='10-K', limit=5)
+
+# Get actual filing CONTENT as Markdown (LLM-ready)
+fmpsdk.sec_filings_data(symbol, filing_type='10-K', limit=1)
+# WARNING: Full 10-K content is VERY long (100k+ tokens)
+```
+
+### Earnings & Transcripts
+```python
+fmpsdk.earning_call_transcript(symbol, year=2024, quarter=1)
+fmpsdk.batch_earning_call_transcript(symbol, year=2024)
+fmpsdk.earning_call_transcripts_available_dates(symbol)
+```
+
+### Company Analysis
+```python
+fmpsdk.company_profile(symbol)          # Overview, CEO, sector, etc.
+fmpsdk.key_metrics(symbol, period='annual', limit=10)
+fmpsdk.financial_ratios(symbol, period='annual', limit=10)
+fmpsdk.analyst_estimates(symbol)
+fmpsdk.analyst_recommendation(symbol)
+```
+
+### News & Events
+```python
+fmpsdk.stock_news(symbol, limit=50)
+fmpsdk.press_releases(symbol, limit=20)
+fmpsdk.earning_calendar(from_date='2024-01-01', to_date='2024-12-31')
+```
+
+## Development Guidelines
+
+### Before Every Commit
+
+```bash
+# Run local code review
+/review-staged
+
+# Fix any issues found
+/fix-review
+```
+
+### Adding New Endpoints
+
+1. Identify the FMP API endpoint and version (v3 or v4)
+2. Add function to appropriate module (or create new module)
+3. Follow the standard function signature pattern
+4. Add to `__init__.py` imports and `__all__` list
+5. Include docstring with `:param`, `:return`, `:example:`
+6. Run `/review-staged` to verify
+
+### Testing
+
+```bash
+# Run tests (when implemented)
+cd src/fmpsdk
+poetry run pytest
+
+# Manual testing
+poetry run python -c "import fmpsdk; print(fmpsdk.company_profile('AAPL'))"
+```
+
+### Linting
+
+```bash
+poetry run black fmpsdk/
+poetry run isort fmpsdk/
+poetry run flake8 fmpsdk/
+poetry run mypy fmpsdk/
+```
+
+## Code Review
+
+Local code review is configured via `.claude/` directory:
+
+```
+.claude/
+├── agents/
+│   └── code-reviewer.md    # Review rules and patterns
+└── commands/
+    ├── review-staged.md    # /review-staged command
+    └── fix-review.md       # /fix-review command
+```
+
+### BLOCK-Level Checks (Must Fix)
+1. Missing `API_KEY` usage from environment variable
+2. Wrong API version (v3 vs v4) for endpoint
+3. Missing `format_output()` call when function has `output` param
+4. New public function not exported in `__init__.py`
+5. Inconsistent function signature pattern
+6. Missing type hints on public functions
+7. File writes without context manager
+
+### WARN-Level Checks (Should Fix)
+1. Missing docstring
+2. Missing `:example:` in docstring
+3. Hardcoded limit instead of `DEFAULT_LIMIT`
+4. Missing period validation (`__validate_period`)
+5. Broad exception handling
+6. Missing error logging
+
+## Known Issues / TODO
+
+1. **Rate Limiting**: No built-in rate limiting - FMP has limits based on plan
+2. **Async Support**: All functions are synchronous (uses `requests`)
+3. **Test Coverage**: Minimal test coverage
+4. **Type Hints**: Partially implemented
+5. **README Outdated**: States "synced as of 20210220" - many newer endpoints exist
+
+## FMP API Reference
+
+- Full API docs: https://site.financialmodelingprep.com/developer/docs
+- 159+ endpoints currently implemented
+- ~150+ additional endpoints available in FMP API not yet in SDK
+
+## Git Submodule Note
+
+This repository is included as a git submodule in the parent GenAI.Financial project at `src/fmpsdk/`. Changes should be committed to both the submodule and the parent repository.
+
+```bash
+# After making changes to fmpsdk
+cd src/fmpsdk
+git add . && git commit -m "feat: Description"
+git push origin main
+
+# Then in parent repo
+cd ../..
+git add src/fmpsdk
+git commit -m "chore: Update fmpsdk submodule"
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,8 +17,8 @@ This is a **forked and customized** Python SDK for the [Financial Modeling Prep 
 fmpsdk/
 ├── __init__.py          # Root package (re-exports fmpsdk/)
 ├── fmpsdk/              # Main SDK package
-│   ├── __init__.py      # Exports 159 public functions
-│   ├── url_methods.py   # Core HTTP methods (__return_json_v3, __return_json_v4)
+│   ├── __init__.py      # Exports 178 public functions
+│   ├── url_methods.py   # Core HTTP methods (__return_json_v3, __return_json_v4, __return_json_stable)
 │   ├── settings.py      # Constants (BASE_URLs, valid values, filenames)
 │   ├── data_compression.py  # Output formatting (TSV, Markdown, JSON)
 │   │
@@ -98,16 +98,45 @@ fmpsdk.income_statement('AAPL', output='tsv')
 
 - **v3 API** (`__return_json_v3`): Most endpoints - financial statements, quotes, company data
 - **v4 API** (`__return_json_v4`): Newer endpoints - batch transcripts, core info, outlook
+- **Stable API** (`__return_json_stable`): Latest endpoints - TTM statements, aftermarket data, ratings snapshots
 
 ### Error Handling
 
-Functions return `None` on API errors (logged to console). Check return values:
+**API Responses:**
+Functions return `None` on API errors with detailed logging. Check return values:
 
 ```python
 result = fmpsdk.company_profile('AAPL')
 if result is None:
-    # Handle error - check logs for details
+    # Handle error - check logs for detailed error messages
+    # Logs include HTTP status codes (401, 403, 404, 429, 5xx)
 ```
+
+**Validation Errors:**
+Parameter validation functions raise `ValueError` for invalid inputs:
+
+```python
+try:
+    fmpsdk.historical_chart('AAPL', timeframe='invalid', ...)
+except ValueError as e:
+    # e.g., "Invalid time_delta value: 'invalid'. Valid options: ['1min', '5min', ...]"
+    pass
+```
+
+**Custom Exception:**
+The `FMPAPIError` exception class is available for structured error handling:
+
+```python
+from fmpsdk import FMPAPIError
+# Can be raised for API-specific errors with status_code and url attributes
+```
+
+**HTTP Status Code Handling:**
+- `401`: Authentication failed - check FMP_API_KEY
+- `403`: Access forbidden - endpoint may not be in your plan
+- `404`: Resource not found - symbol or endpoint doesn't exist
+- `429`: Rate limit exceeded - reduce request frequency
+- `5xx`: Server error - retry later
 
 ## Key Functions for Case Studies
 
@@ -233,8 +262,9 @@ Local code review is configured via `.claude/` directory:
 ## FMP API Reference
 
 - Full API docs: https://site.financialmodelingprep.com/developer/docs
-- 159+ endpoints currently implemented
-- ~150+ additional endpoints available in FMP API not yet in SDK
+- 170 endpoints currently implemented in the registry
+- 178 public functions exported (including registry utilities)
+- ~140+ additional endpoints available in FMP API not yet in SDK
 
 ## Git Submodule Note
 

--- a/fmpsdk/__init__.py
+++ b/fmpsdk/__init__.py
@@ -203,6 +203,17 @@ from .valuation_metrics import (
     historical_market_capitalization,
 )
 
+from .fmp_registry import (
+    FMPEndpoint,
+    FMP_REGISTRY,
+    CATEGORIES,
+    get_endpoints_by_category,
+    get_all_categories,
+    get_registry_for_llm,
+    get_compact_registry_for_llm,
+    search_endpoints,
+)
+
 attribution: str = "Data provided by Financial Modeling Prep"
 logging.info(attribution)
 
@@ -366,4 +377,13 @@ __all__ = [
     "upgrades_downgrades_by_company",
     "upgrades_downgrades_consensus",
     "upgrades_downgrades_rss_feed",
+    # Registry exports
+    "FMPEndpoint",
+    "FMP_REGISTRY",
+    "CATEGORIES",
+    "get_endpoints_by_category",
+    "get_all_categories",
+    "get_registry_for_llm",
+    "get_compact_registry_for_llm",
+    "search_endpoints",
 ]

--- a/fmpsdk/__init__.py
+++ b/fmpsdk/__init__.py
@@ -65,6 +65,8 @@ from .company_valuation import (
     historical_employee_count,
     employee_count,
     analyst_recommendation,
+    ratings_snapshot,
+    grades_consensus,
 )
 
 from .crowdfunding import (
@@ -99,6 +101,11 @@ from .financial_statements import (
     earning_call_transcripts_available_dates,
     sec_filings,
     sec_filings_data,
+    income_statement_ttm,
+    balance_sheet_statement_ttm,
+    cash_flow_statement_ttm,
+    latest_financial_statements,
+    earning_call_transcript_latest,
 )
 from .insider_trading import (
     insider_trading, 
@@ -161,6 +168,8 @@ from .quote import (
     forex_quote,
     historical_chart,
     historical_price_full,
+    aftermarket_trade,
+    aftermarket_quote,
 )
 from .search_functions import search, search_ticker
 from .senate import (
@@ -187,6 +196,8 @@ from .stock_market import (
     batch_eod_prices,
     multiple_company_prices,
     historical_sectors_performance,
+    industry_performance_snapshot,
+    holidays_by_exchange,
 )
 from .stock_screener import stock_screener
 from .stock_time_series import (
@@ -214,12 +225,16 @@ from .fmp_registry import (
     search_endpoints,
 )
 
+from .url_methods import FMPAPIError
+
 attribution: str = "Data provided by Financial Modeling Prep"
 logging.info(attribution)
 
 __all__ = [
     "actives",
     "advanced_discounted_cash_flow",
+    "aftermarket_quote",
+    "aftermarket_trade",
     "all_countries",
     "analyst_estimates",
     "analyst_recommendation",
@@ -238,11 +253,13 @@ __all__ = [
     "balance_sheet_statement",
     "balance_sheet_statement_as_reported",
     "balance_sheet_statement_growth",
+    "balance_sheet_statement_ttm",
     "batch_earning_call_transcript",
     "batch_eod_prices",
     "cash_flow_statement",
     "cash_flow_statement_as_reported",
     "cash_flow_statement_growth",
+    "cash_flow_statement_ttm",
     "cik",
     "cik_list",
     "cik_search",
@@ -267,6 +284,7 @@ __all__ = [
     "dividend_calendar",
     "dowjones_constituent",
     "earning_call_transcript",
+    "earning_call_transcript_latest",
     "earning_call_transcripts_available_dates",
     "earning_calendar",
     "earnings_surprises",
@@ -289,6 +307,7 @@ __all__ = [
     "financial_statement_full_as_reported",
     "financial_statement_symbol_lists",
     "fmp_articles",
+    "FMPAPIError",
     "form_13f",
     "forex",
     "forex_historical",
@@ -296,6 +315,7 @@ __all__ = [
     "forex_quote",
     "gainers",
     "general_news",
+    "grades_consensus",
     "historical_chart",
     "historical_daily_discounted_cash_flow",
     "historical_dowjones_constituent",
@@ -307,6 +327,7 @@ __all__ = [
     "historical_rating",
     "historical_sectors_performance",
     "historical_share_float",
+    "holidays_by_exchange",
     "historical_social_sentiment",
     "historical_sp500_constituent",
     "historical_stock_dividend",
@@ -314,8 +335,10 @@ __all__ = [
     "income_statement",
     "income_statement_as_reported",
     "income_statement_growth",
+    "income_statement_ttm",
     "indexes",
     "industry_pe_ratio",
+    "industry_performance_snapshot",
     "insider_trading",
     "insider_trading_rss_feed",
     "institutional_holders",
@@ -324,6 +347,7 @@ __all__ = [
     "key_executives",
     "key_metrics",
     "key_metrics_ttm",
+    "latest_financial_statements",
     "losers",
     "mapper_cik_company",
     "mapper_cik_name",
@@ -346,6 +370,7 @@ __all__ = [
     "quote",
     "quote_short",
     "rating",
+    "ratings_snapshot",
     "revenue_geographic_segmentation",
     "sales_revenue_by_segments",
     "search",

--- a/fmpsdk/company_valuation.py
+++ b/fmpsdk/company_valuation.py
@@ -1,7 +1,7 @@
 import typing
 import os
 from .settings import DEFAULT_LIMIT
-from .url_methods import __return_json_v3, __return_json_v4, __validate_period
+from .url_methods import __return_json_v3, __return_json_v4, __return_json_stable, __validate_period
 from .data_compression import format_output
 from typing import List, Dict, Union
 
@@ -439,4 +439,46 @@ def analyst_recommendation(
     path = f"analyst-stock-recommendations/{symbol}"
     query_vars = {"apikey": API_KEY}
     result = __return_json_v3(path=path, query_vars=query_vars)
+    return format_output(result, output)
+
+
+def ratings_snapshot(
+    symbol: str,
+    output: str = 'markdown'
+) -> Union[List[Dict], str]:
+    """
+    Retrieve a snapshot of analyst ratings for a company.
+
+    Provides a quick summary of buy, hold, sell, and strong buy/sell recommendations
+    from analysts, useful for gauging overall market sentiment.
+
+    :param symbol: Company ticker (e.g., 'AAPL').
+    :param output: Output format ('tsv', 'json', or 'markdown'). Defaults to 'markdown'.
+    :return: Ratings snapshot data in the specified format.
+    :example: ratings_snapshot('AAPL')
+    """
+    path = "ratings-snapshot"
+    query_vars = {"apikey": API_KEY, "symbol": symbol}
+    result = __return_json_stable(path=path, query_vars=query_vars)
+    return format_output(result, output)
+
+
+def grades_consensus(
+    symbol: str,
+    output: str = 'markdown'
+) -> Union[List[Dict], str]:
+    """
+    Retrieve the consensus grade for a company from analyst ratings.
+
+    Provides an aggregated view of analyst grades including the consensus
+    recommendation (buy, hold, sell) based on all analyst inputs.
+
+    :param symbol: Company ticker (e.g., 'AAPL').
+    :param output: Output format ('tsv', 'json', or 'markdown'). Defaults to 'markdown'.
+    :return: Grades consensus data in the specified format.
+    :example: grades_consensus('AAPL')
+    """
+    path = "grades-consensus"
+    query_vars = {"apikey": API_KEY, "symbol": symbol}
+    result = __return_json_stable(path=path, query_vars=query_vars)
     return format_output(result, output)

--- a/fmpsdk/financial_statements.py
+++ b/fmpsdk/financial_statements.py
@@ -59,7 +59,8 @@ def income_statement(
     if download:
         query_vars["datatype"] = "csv"  # Only CSV is supported.
         response = requests.get(f"{BASE_URL_v3}{path}", params=query_vars)
-        open(filename, "wb").write(response.content)
+        with open(filename, "wb") as f:
+            f.write(response.content)
         logging.info(f"Saving {symbol} financial statement as {filename}.")
         return None
     else:
@@ -96,7 +97,8 @@ def balance_sheet_statement(
     if download:
         query_vars["datatype"] = "csv"  # Only CSV is supported.
         response = requests.get(f"{BASE_URL_v3}{path}", params=query_vars)
-        open(filename, "wb").write(response.content)
+        with open(filename, "wb") as f:
+            f.write(response.content)
         logging.info(f"Saving {symbol} balance sheet statement as {filename}.")
         return None
     else:
@@ -133,7 +135,8 @@ def cash_flow_statement(
     if download:
         query_vars["datatype"] = "csv"  # Only CSV is supported.
         response = requests.get(f"{BASE_URL_v3}{path}", params=query_vars)
-        open(filename, "wb").write(response.content)
+        with open(filename, "wb") as f:
+            f.write(response.content)
         logging.info(f"Saving {symbol} financial statement as {filename}.")
         return None
     else:
@@ -170,7 +173,8 @@ def income_statement_as_reported(
     if download:
         query_vars["datatype"] = "csv"  # Only CSV is supported.
         response = requests.get(f"{BASE_URL_v3}{path}", params=query_vars)
-        open(filename, "wb").write(response.content)
+        with open(filename, "wb") as f:
+            f.write(response.content)
         logging.info(f"Saving {symbol} financial statement as {filename}.")
         return None
     else:
@@ -206,7 +210,8 @@ def balance_sheet_statement_as_reported(
     if download:
         query_vars["datatype"] = "csv"  # Only CSV is supported.
         response = requests.get(f"{BASE_URL_v3}{path}", params=query_vars)
-        open(filename, "wb").write(response.content)
+        with open(filename, "wb") as f:
+            f.write(response.content)
         logging.info(f"Saving {symbol} financial statement as {filename}.")
         return None
     else:
@@ -242,7 +247,8 @@ def cash_flow_statement_as_reported(
     if download:
         query_vars["datatype"] = "csv"  # Only CSV is supported.
         response = requests.get(f"{BASE_URL_v3}{path}", params=query_vars)
-        open(filename, "wb").write(response.content)
+        with open(filename, "wb") as f:
+            f.write(response.content)
         logging.info(f"Saving {symbol} financial statement as {filename}.")
         return None
     else:

--- a/fmpsdk/financial_statements.py
+++ b/fmpsdk/financial_statements.py
@@ -20,6 +20,7 @@ from .settings import (
 from .url_methods import (
     __return_json_v3,
     __return_json_v4,
+    __return_json_stable,
     __validate_industry,
     __validate_period,
     __validate_sector,
@@ -519,3 +520,112 @@ def sec_filings_data(symbol, filing_type='10-K', limit=1):
             finalcontent += f"\nNo direct link available for {filing_type} filing of {symbol}"
     
     return finalcontent or {"error": f"Failed to retrieve content for {symbol} {filing_type} filings"}
+
+
+def income_statement_ttm(
+    symbol: str,
+    output: str = 'markdown'
+) -> typing.Union[typing.List[typing.Dict], str]:
+    """
+    Retrieve trailing twelve months (TTM) income statement data for a company.
+
+    Provides the most recent 12-month aggregated income statement data,
+    useful for analyzing current profitability trends without waiting
+    for quarterly or annual reports.
+
+    :param symbol: Company ticker (e.g., 'AAPL').
+    :param output: Output format ('tsv', 'json', or 'markdown'). Defaults to 'markdown'.
+    :return: List of dicts or formatted string with TTM income statement data.
+    :example: income_statement_ttm('AAPL')
+    """
+    path = "income-statement-ttm"
+    query_vars = {"apikey": API_KEY, "symbol": symbol}
+    result = __return_json_stable(path=path, query_vars=query_vars)
+    return format_output(result, output)
+
+
+def balance_sheet_statement_ttm(
+    symbol: str,
+    output: str = 'markdown'
+) -> typing.Union[typing.List[typing.Dict], str]:
+    """
+    Retrieve trailing twelve months (TTM) balance sheet data for a company.
+
+    Provides the most recent balance sheet snapshot, useful for analyzing
+    current financial position including assets, liabilities, and equity.
+
+    :param symbol: Company ticker (e.g., 'AAPL').
+    :param output: Output format ('tsv', 'json', or 'markdown'). Defaults to 'markdown'.
+    :return: List of dicts or formatted string with TTM balance sheet data.
+    :example: balance_sheet_statement_ttm('AAPL')
+    """
+    path = "balance-sheet-statement-ttm"
+    query_vars = {"apikey": API_KEY, "symbol": symbol}
+    result = __return_json_stable(path=path, query_vars=query_vars)
+    return format_output(result, output)
+
+
+def cash_flow_statement_ttm(
+    symbol: str,
+    output: str = 'markdown'
+) -> typing.Union[typing.List[typing.Dict], str]:
+    """
+    Retrieve trailing twelve months (TTM) cash flow statement data for a company.
+
+    Provides the most recent 12-month aggregated cash flow data,
+    useful for analyzing current cash generation and usage patterns.
+
+    :param symbol: Company ticker (e.g., 'AAPL').
+    :param output: Output format ('tsv', 'json', or 'markdown'). Defaults to 'markdown'.
+    :return: List of dicts or formatted string with TTM cash flow statement data.
+    :example: cash_flow_statement_ttm('AAPL')
+    """
+    path = "cash-flow-statement-ttm"
+    query_vars = {"apikey": API_KEY, "symbol": symbol}
+    result = __return_json_stable(path=path, query_vars=query_vars)
+    return format_output(result, output)
+
+
+def latest_financial_statements(
+    page: int = 0,
+    limit: int = 250,
+    output: str = 'markdown'
+) -> typing.Union[typing.List[typing.Dict], str]:
+    """
+    Retrieve the latest financial statements filed by all companies.
+
+    Provides a paginated list of the most recently filed financial statements,
+    useful for monitoring new filings across the market or finding recently
+    updated company financials.
+
+    :param page: Page number for pagination (0-indexed). Default is 0.
+    :param limit: Number of records per page. Default is 250.
+    :param output: Output format ('tsv', 'json', or 'markdown'). Defaults to 'markdown'.
+    :return: List of dicts or formatted string with latest financial statement data.
+    :example: latest_financial_statements(page=0, limit=50)
+    """
+    path = "latest-financial-statements"
+    query_vars = {"apikey": API_KEY, "page": page, "limit": limit}
+    result = __return_json_stable(path=path, query_vars=query_vars)
+    return format_output(result, output)
+
+
+def earning_call_transcript_latest(
+    symbol: str,
+    output: str = 'markdown'
+) -> typing.Union[typing.List[typing.Dict], str]:
+    """
+    Retrieve the most recent earnings call transcript for a company.
+
+    Provides quick access to the latest earnings call without needing
+    to specify year and quarter parameters.
+
+    :param symbol: Company ticker (e.g., 'AAPL').
+    :param output: Output format ('tsv', 'json', or 'markdown'). Defaults to 'markdown'.
+    :return: List of dicts or formatted string with the latest earnings call transcript.
+    :example: earning_call_transcript_latest('AAPL')
+    """
+    path = "earning-call-transcript-latest"
+    query_vars = {"apikey": API_KEY, "symbol": symbol}
+    result = __return_json_stable(path=path, query_vars=query_vars)
+    return format_output(result, output)

--- a/fmpsdk/fmp_registry.py
+++ b/fmpsdk/fmp_registry.py
@@ -1,0 +1,2772 @@
+"""
+FMP Endpoint Registry for LLM-powered data source selection.
+
+This module provides a comprehensive registry of all FMP (Financial Modeling Prep)
+endpoints available in the fmpsdk package. Each endpoint is documented with
+LLM-friendly descriptions, parameters, use cases, and return types.
+
+Usage:
+    from fmpsdk.fmp_registry import FMP_REGISTRY, get_registry_for_llm, get_endpoints_by_category
+
+    # Get all endpoints in a category
+    financials = get_endpoints_by_category('financials')
+
+    # Get LLM-friendly formatted context
+    context = get_registry_for_llm()
+"""
+
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+
+@dataclass
+class FMPEndpoint:
+    """Registry entry for an FMP endpoint."""
+
+    name: str  # Canonical name (e.g., "income_statement")
+    function: str  # fmpsdk function name
+    description: str  # LLM-friendly description
+    category: str  # Category for grouping
+    parameters: Dict[str, Any]  # Available params with types and defaults
+    example_use_cases: List[str]  # When to use this endpoint
+    returns: str  # Description of return data structure
+    notes: Optional[str] = None  # Any caveats or special handling
+
+
+# =============================================================================
+# FMP ENDPOINT REGISTRY
+# =============================================================================
+
+FMP_REGISTRY: Dict[str, FMPEndpoint] = {
+    # =========================================================================
+    # FINANCIAL STATEMENTS
+    # =========================================================================
+    "income_statement": FMPEndpoint(
+        name="income_statement",
+        function="income_statement",
+        description="Annual or quarterly income statement data including revenue, expenses, and net income. Shows profitability trends over time.",
+        category="financials",
+        parameters={
+            "symbol": {"type": "str", "required": True, "description": "Stock ticker (e.g., 'AAPL')"},
+            "period": {"type": "str", "required": False, "default": "annual", "options": ["annual", "quarter"]},
+            "limit": {"type": "int", "required": False, "default": 10, "description": "Number of periods to retrieve"},
+            "output": {"type": "str", "required": False, "default": "markdown", "options": ["markdown", "json", "tsv"]},
+        },
+        example_use_cases=[
+            "Revenue trend analysis over multiple years",
+            "Profitability assessment and margin analysis",
+            "Year-over-year growth comparison",
+            "Cost structure analysis",
+        ],
+        returns="List of income statements with date, revenue, grossProfit, operatingIncome, netIncome, eps, etc.",
+    ),
+    "balance_sheet_statement": FMPEndpoint(
+        name="balance_sheet_statement",
+        function="balance_sheet_statement",
+        description="Annual or quarterly balance sheet data including assets, liabilities, and equity. Shows financial position at specific points in time.",
+        category="financials",
+        parameters={
+            "symbol": {"type": "str", "required": True, "description": "Stock ticker or CIK"},
+            "period": {"type": "str", "required": False, "default": "annual", "options": ["annual", "quarter"]},
+            "limit": {"type": "int", "required": False, "default": 10},
+            "output": {"type": "str", "required": False, "default": "markdown"},
+        },
+        example_use_cases=[
+            "Asset composition analysis",
+            "Debt level assessment",
+            "Working capital analysis",
+            "Shareholder equity trends",
+        ],
+        returns="List of balance sheets with totalAssets, totalLiabilities, totalEquity, cash, inventory, etc.",
+    ),
+    "cash_flow_statement": FMPEndpoint(
+        name="cash_flow_statement",
+        function="cash_flow_statement",
+        description="Annual or quarterly cash flow statement showing operating, investing, and financing activities. Reveals actual cash generation and usage.",
+        category="financials",
+        parameters={
+            "symbol": {"type": "str", "required": True, "description": "Stock ticker or CIK"},
+            "period": {"type": "str", "required": False, "default": "annual", "options": ["annual", "quarter"]},
+            "limit": {"type": "int", "required": False, "default": 10},
+            "output": {"type": "str", "required": False, "default": "markdown"},
+        },
+        example_use_cases=[
+            "Free cash flow analysis",
+            "Capital expenditure trends",
+            "Dividend sustainability assessment",
+            "Cash conversion analysis",
+        ],
+        returns="List of cash flow statements with operatingCashFlow, investingCashFlow, financingCashFlow, freeCashFlow, etc.",
+    ),
+    "income_statement_as_reported": FMPEndpoint(
+        name="income_statement_as_reported",
+        function="income_statement_as_reported",
+        description="Income statement exactly as reported in SEC filings, without standardization. Useful for detailed analysis matching company-specific terminology.",
+        category="financials",
+        parameters={
+            "symbol": {"type": "str", "required": True},
+            "period": {"type": "str", "required": False, "default": "annual"},
+            "limit": {"type": "int", "required": False, "default": 10},
+            "output": {"type": "str", "required": False, "default": "markdown"},
+        },
+        example_use_cases=[
+            "Detailed SEC filing analysis",
+            "Company-specific line item research",
+            "Audit and compliance checks",
+        ],
+        returns="As-reported income statement data with original SEC filing field names.",
+    ),
+    "balance_sheet_statement_as_reported": FMPEndpoint(
+        name="balance_sheet_statement_as_reported",
+        function="balance_sheet_statement_as_reported",
+        description="Balance sheet exactly as reported in SEC filings, without standardization.",
+        category="financials",
+        parameters={
+            "symbol": {"type": "str", "required": True},
+            "period": {"type": "str", "required": False, "default": "annual"},
+            "limit": {"type": "int", "required": False, "default": 10},
+            "output": {"type": "str", "required": False, "default": "markdown"},
+        },
+        example_use_cases=[
+            "Detailed SEC filing analysis",
+            "Company-specific asset/liability categorization",
+        ],
+        returns="As-reported balance sheet data with original SEC filing field names.",
+    ),
+    "cash_flow_statement_as_reported": FMPEndpoint(
+        name="cash_flow_statement_as_reported",
+        function="cash_flow_statement_as_reported",
+        description="Cash flow statement exactly as reported in SEC filings, without standardization.",
+        category="financials",
+        parameters={
+            "symbol": {"type": "str", "required": True},
+            "period": {"type": "str", "required": False, "default": "annual"},
+            "limit": {"type": "int", "required": False, "default": 10},
+            "output": {"type": "str", "required": False, "default": "markdown"},
+        },
+        example_use_cases=[
+            "Detailed SEC filing analysis",
+            "Company-specific cash flow categorization",
+        ],
+        returns="As-reported cash flow statement data with original SEC filing field names.",
+    ),
+    "financial_statement_full_as_reported": FMPEndpoint(
+        name="financial_statement_full_as_reported",
+        function="financial_statement_full_as_reported",
+        description="Complete financial statements as reported in SEC filings, combining income, balance sheet, and cash flow.",
+        category="financials",
+        parameters={
+            "symbol": {"type": "str", "required": True},
+            "period": {"type": "str", "required": False, "default": "annual"},
+            "output": {"type": "str", "required": False, "default": "markdown"},
+        },
+        example_use_cases=[
+            "Comprehensive SEC filing analysis",
+            "Full financial picture from original filings",
+        ],
+        returns="Complete as-reported financial statement data.",
+    ),
+    "earnings_surprises": FMPEndpoint(
+        name="earnings_surprises",
+        function="earnings_surprises",
+        description="Historical earnings surprises showing actual vs estimated EPS. Reveals how often a company beats or misses expectations.",
+        category="financials",
+        parameters={
+            "symbol": {"type": "str", "required": True},
+            "output": {"type": "str", "required": False, "default": "markdown"},
+        },
+        example_use_cases=[
+            "Earnings beat/miss pattern analysis",
+            "Management guidance accuracy assessment",
+            "Earnings quality evaluation",
+        ],
+        returns="List of earnings surprises with date, actualEarningResult, estimatedEarning, surprise percentage.",
+    ),
+    # =========================================================================
+    # EARNINGS & TRANSCRIPTS
+    # =========================================================================
+    "earning_call_transcript": FMPEndpoint(
+        name="earning_call_transcript",
+        function="earning_call_transcript",
+        description="Full text transcript of earnings call for a specific quarter. Contains management commentary, guidance, and Q&A with analysts.",
+        category="earnings",
+        parameters={
+            "symbol": {"type": "str", "required": True},
+            "year": {"type": "int", "required": True, "description": "Year (e.g., 2024)"},
+            "quarter": {"type": "int", "required": True, "description": "Quarter (1-4)"},
+            "output": {"type": "str", "required": False, "default": "markdown"},
+        },
+        example_use_cases=[
+            "Management sentiment analysis",
+            "Strategic initiative tracking",
+            "Guidance and outlook extraction",
+            "Competitive intelligence from Q&A",
+        ],
+        returns="Earnings call transcript text with date, symbol, quarter, year, and content.",
+        notes="Transcripts can be very long (10k+ words). Consider token limits.",
+    ),
+    "batch_earning_call_transcript": FMPEndpoint(
+        name="batch_earning_call_transcript",
+        function="batch_earning_call_transcript",
+        description="All earnings call transcripts for a company in a given year. Efficient for annual analysis.",
+        category="earnings",
+        parameters={
+            "symbol": {"type": "str", "required": True},
+            "year": {"type": "int", "required": True},
+            "output": {"type": "str", "required": False, "default": "markdown"},
+        },
+        example_use_cases=[
+            "Full year management commentary analysis",
+            "Quarterly guidance evolution tracking",
+            "Annual narrative analysis",
+        ],
+        returns="Multiple earnings call transcripts for all quarters in the year.",
+        notes="Very large data return - may hit token limits.",
+    ),
+    "earning_call_transcripts_available_dates": FMPEndpoint(
+        name="earning_call_transcripts_available_dates",
+        function="earning_call_transcripts_available_dates",
+        description="List of available earnings call transcript dates for a company. Use to discover which transcripts are available.",
+        category="earnings",
+        parameters={
+            "symbol": {"type": "str", "required": True},
+        },
+        example_use_cases=[
+            "Discover available transcript dates before fetching",
+            "Plan transcript analysis scope",
+        ],
+        returns="List of [quarter, year] pairs with available transcripts.",
+    ),
+    # =========================================================================
+    # SEC FILINGS
+    # =========================================================================
+    "sec_filings": FMPEndpoint(
+        name="sec_filings",
+        function="sec_filings",
+        description="SEC filing metadata and links (10-K, 10-Q, 8-K, etc.). Returns filing dates, types, and URLs but NOT the actual content.",
+        category="sec",
+        parameters={
+            "symbol": {"type": "str", "required": True},
+            "filing_type": {"type": "str", "required": False, "default": "", "options": ["10-K", "10-Q", "8-K", "DEF 14A", "S-1", "etc"]},
+            "limit": {"type": "int", "required": False, "default": 10},
+        },
+        example_use_cases=[
+            "Find SEC filing links for further analysis",
+            "Track filing history and timing",
+            "Identify recent 8-K events",
+        ],
+        returns="List of filings with type, fillingDate, acceptedDate, cik, link, finalLink.",
+    ),
+    "sec_filings_data": FMPEndpoint(
+        name="sec_filings_data",
+        function="sec_filings_data",
+        description="Full text content of SEC filings rendered as Markdown. Fetches and parses actual filing content from SEC EDGAR.",
+        category="sec",
+        parameters={
+            "symbol": {"type": "str", "required": True},
+            "filing_type": {"type": "str", "required": False, "default": "10-K", "options": ["10-K", "10-Q", "8-K"]},
+            "limit": {"type": "int", "required": False, "default": 1},
+        },
+        example_use_cases=[
+            "Deep 10-K analysis for risk factors, business description",
+            "8-K event analysis for material events",
+            "Historical 10-K trend analysis",
+        ],
+        returns="Full Markdown-formatted SEC filing content.",
+        notes="WARNING: Full 10-K content is VERY long (100k+ tokens). Limit to 1-2 filings max.",
+    ),
+    # =========================================================================
+    # COMPANY PROFILE & INFO
+    # =========================================================================
+    "company_profile": FMPEndpoint(
+        name="company_profile",
+        function="company_profile",
+        description="Comprehensive company overview including price, market cap, sector, industry, CEO, description, headquarters, website, and key statistics.",
+        category="company",
+        parameters={
+            "symbol": {"type": "str", "required": True},
+            "output": {"type": "str", "required": False, "default": "markdown"},
+        },
+        example_use_cases=[
+            "Company overview and background research",
+            "Sector and industry classification",
+            "Market cap and basic statistics",
+            "Company description for reports",
+        ],
+        returns="Company profile with symbol, price, beta, mktCap, description, sector, industry, ceo, website, etc.",
+    ),
+    "key_executives": FMPEndpoint(
+        name="key_executives",
+        function="key_executives",
+        description="Key executives data from SEC filings including names, titles, and compensation.",
+        category="company",
+        parameters={
+            "symbol": {"type": "str", "required": True},
+            "output": {"type": "str", "required": False, "default": "markdown"},
+        },
+        example_use_cases=[
+            "Management team analysis",
+            "Executive compensation research",
+            "Corporate governance assessment",
+        ],
+        returns="List of executives with name, title, pay, currencyPay, etc.",
+    ),
+    "company_core_information": FMPEndpoint(
+        name="company_core_information",
+        function="company_core_information",
+        description="Core company information including CIK, exchange, SIC code, and state of incorporation.",
+        category="company",
+        parameters={
+            "symbol": {"type": "str", "required": True},
+            "output": {"type": "str", "required": False, "default": "markdown"},
+        },
+        example_use_cases=[
+            "Regulatory and compliance research",
+            "Company registration details",
+        ],
+        returns="Core info with cik, exchange, sicCode, sicDescription, stateOfIncorporation, etc.",
+    ),
+    "company_outlook": FMPEndpoint(
+        name="company_outlook",
+        function="company_outlook",
+        description="Comprehensive company outlook combining profile, metrics, ratios, and stock data in one call.",
+        category="company",
+        parameters={
+            "symbol": {"type": "str", "required": True},
+            "output": {"type": "str", "required": False, "default": "markdown"},
+        },
+        example_use_cases=[
+            "Quick comprehensive company snapshot",
+            "All-in-one company analysis",
+        ],
+        returns="Combined data including profile, metrics, ratios, stock data, insider transactions, and more.",
+    ),
+    "enterprise_values": FMPEndpoint(
+        name="enterprise_values",
+        function="enterprise_values",
+        description="Enterprise value data including market cap, debt, and cash. Shows total company value for M&A analysis.",
+        category="company",
+        parameters={
+            "symbol": {"type": "str", "required": True},
+            "period": {"type": "str", "required": False, "default": "annual"},
+            "limit": {"type": "int", "required": False, "default": 10},
+            "output": {"type": "str", "required": False, "default": "markdown"},
+        },
+        example_use_cases=[
+            "M&A valuation analysis",
+            "EV/EBITDA calculations",
+            "Capital structure analysis",
+        ],
+        returns="Enterprise value data with date, symbol, enterpriseValue, numberOfShares, addTotalDebt, minusCashAndEquivalents.",
+    ),
+    # =========================================================================
+    # KEY METRICS & RATIOS
+    # =========================================================================
+    "key_metrics": FMPEndpoint(
+        name="key_metrics",
+        function="key_metrics",
+        description="Key financial metrics including revenue per share, PE ratio, debt to equity, ROE, and more.",
+        category="metrics",
+        parameters={
+            "symbol": {"type": "str", "required": True},
+            "period": {"type": "str", "required": False, "default": "annual"},
+            "limit": {"type": "int", "required": False, "default": 10},
+            "output": {"type": "str", "required": False, "default": "markdown"},
+            "precision": {"type": "int", "required": False, "default": 5},
+        },
+        example_use_cases=[
+            "Valuation metrics analysis",
+            "Profitability metrics tracking",
+            "Leverage and efficiency ratios",
+        ],
+        returns="Key metrics with revenuePerShare, netIncomePerShare, peRatio, debtToEquity, returnOnEquity, etc.",
+    ),
+    "key_metrics_ttm": FMPEndpoint(
+        name="key_metrics_ttm",
+        function="key_metrics_ttm",
+        description="Trailing twelve months (TTM) key metrics for most recent performance snapshot.",
+        category="metrics",
+        parameters={
+            "symbol": {"type": "str", "required": True},
+            "limit": {"type": "int", "required": False, "default": 10},
+            "output": {"type": "str", "required": False, "default": "markdown"},
+            "precision": {"type": "int", "required": False, "default": 5},
+        },
+        example_use_cases=[
+            "Current valuation metrics",
+            "Real-time performance snapshot",
+        ],
+        returns="TTM key metrics data.",
+    ),
+    "financial_ratios": FMPEndpoint(
+        name="financial_ratios",
+        function="financial_ratios",
+        description="Comprehensive financial ratios including liquidity, profitability, debt, and efficiency ratios.",
+        category="metrics",
+        parameters={
+            "symbol": {"type": "str", "required": True},
+            "period": {"type": "str", "required": False, "default": "annual"},
+            "limit": {"type": "int", "required": False, "default": 10},
+            "output": {"type": "str", "required": False, "default": "markdown"},
+            "precision": {"type": "int", "required": False, "default": 5},
+        },
+        example_use_cases=[
+            "Comprehensive ratio analysis",
+            "Peer comparison",
+            "Credit analysis",
+            "Investment screening",
+        ],
+        returns="Financial ratios including currentRatio, quickRatio, grossProfitMargin, returnOnAssets, debtRatio, etc.",
+    ),
+    "financial_ratios_ttm": FMPEndpoint(
+        name="financial_ratios_ttm",
+        function="financial_ratios_ttm",
+        description="Trailing twelve months financial ratios for current performance.",
+        category="metrics",
+        parameters={
+            "symbol": {"type": "str", "required": True},
+            "output": {"type": "str", "required": False, "default": "markdown"},
+            "precision": {"type": "int", "required": False, "default": 5},
+        },
+        example_use_cases=[
+            "Current ratio analysis",
+            "Real-time performance assessment",
+        ],
+        returns="TTM financial ratios data.",
+    ),
+    # =========================================================================
+    # GROWTH METRICS
+    # =========================================================================
+    "financial_growth": FMPEndpoint(
+        name="financial_growth",
+        function="financial_growth",
+        description="Financial growth metrics showing year-over-year or quarter-over-quarter growth rates.",
+        category="growth",
+        parameters={
+            "symbol": {"type": "str", "required": True},
+            "period": {"type": "str", "required": False, "default": "annual"},
+            "limit": {"type": "int", "required": False, "default": 10},
+            "output": {"type": "str", "required": False, "default": "markdown"},
+            "precision": {"type": "int", "required": False, "default": 5},
+        },
+        example_use_cases=[
+            "Growth trend analysis",
+            "Historical growth rate tracking",
+            "Growth consistency assessment",
+        ],
+        returns="Growth metrics with revenueGrowth, netIncomeGrowth, epsgrowth, etc.",
+    ),
+    "income_statement_growth": FMPEndpoint(
+        name="income_statement_growth",
+        function="income_statement_growth",
+        description="Income statement growth metrics showing revenue and profit growth trends.",
+        category="growth",
+        parameters={
+            "symbol": {"type": "str", "required": True},
+            "limit": {"type": "int", "required": False, "default": 10},
+            "output": {"type": "str", "required": False, "default": "markdown"},
+            "precision": {"type": "int", "required": False, "default": 5},
+        },
+        example_use_cases=[
+            "Revenue growth analysis",
+            "Profit margin trend analysis",
+        ],
+        returns="Income statement growth data.",
+    ),
+    "balance_sheet_statement_growth": FMPEndpoint(
+        name="balance_sheet_statement_growth",
+        function="balance_sheet_statement_growth",
+        description="Balance sheet growth metrics showing asset and liability growth trends.",
+        category="growth",
+        parameters={
+            "symbol": {"type": "str", "required": True},
+            "limit": {"type": "int", "required": False, "default": 10},
+            "output": {"type": "str", "required": False, "default": "markdown"},
+            "precision": {"type": "int", "required": False, "default": 5},
+        },
+        example_use_cases=[
+            "Asset growth analysis",
+            "Debt growth tracking",
+        ],
+        returns="Balance sheet growth data.",
+    ),
+    "cash_flow_statement_growth": FMPEndpoint(
+        name="cash_flow_statement_growth",
+        function="cash_flow_statement_growth",
+        description="Cash flow growth metrics showing operating, investing, and financing cash flow trends.",
+        category="growth",
+        parameters={
+            "symbol": {"type": "str", "required": True},
+            "limit": {"type": "int", "required": False, "default": 10},
+            "output": {"type": "str", "required": False, "default": "markdown"},
+            "precision": {"type": "int", "required": False, "default": 5},
+        },
+        example_use_cases=[
+            "Cash flow growth analysis",
+            "Free cash flow trend tracking",
+        ],
+        returns="Cash flow growth data.",
+    ),
+    # =========================================================================
+    # VALUATION
+    # =========================================================================
+    "discounted_cash_flow": FMPEndpoint(
+        name="discounted_cash_flow",
+        function="discounted_cash_flow",
+        description="DCF valuation estimating intrinsic value based on projected future cash flows.",
+        category="valuation",
+        parameters={
+            "symbol": {"type": "str", "required": True},
+            "output": {"type": "str", "required": False, "default": "markdown"},
+        },
+        example_use_cases=[
+            "Intrinsic value estimation",
+            "Under/overvaluation assessment",
+            "Value investing screening",
+        ],
+        returns="DCF data with date, symbol, dcf (intrinsic value), stockPrice.",
+    ),
+    "advanced_discounted_cash_flow": FMPEndpoint(
+        name="advanced_discounted_cash_flow",
+        function="advanced_discounted_cash_flow",
+        description="Advanced DCF model with detailed assumptions and projections.",
+        category="valuation",
+        parameters={
+            "symbol": {"type": "str", "required": True},
+            "output": {"type": "str", "required": False, "default": "markdown"},
+        },
+        example_use_cases=[
+            "Detailed intrinsic value analysis",
+            "DCF sensitivity analysis",
+        ],
+        returns="Advanced DCF data with detailed projections and assumptions.",
+    ),
+    "historical_daily_discounted_cash_flow": FMPEndpoint(
+        name="historical_daily_discounted_cash_flow",
+        function="historical_daily_discounted_cash_flow",
+        description="Daily historical DCF values showing intrinsic value evolution over time.",
+        category="valuation",
+        parameters={
+            "symbol": {"type": "str", "required": True},
+            "limit": {"type": "int", "required": False, "default": 10},
+            "output": {"type": "str", "required": False, "default": "markdown"},
+        },
+        example_use_cases=[
+            "Historical valuation trends",
+            "Valuation gap analysis over time",
+        ],
+        returns="Historical DCF values with date, symbol, dcf, stockPrice.",
+    ),
+    "market_capitalization": FMPEndpoint(
+        name="market_capitalization",
+        function="market_capitalization",
+        description="Current market capitalization of a company.",
+        category="valuation",
+        parameters={
+            "symbol": {"type": "str", "required": True},
+            "output": {"type": "str", "required": False, "default": "markdown"},
+        },
+        example_use_cases=[
+            "Company size classification",
+            "Market value assessment",
+        ],
+        returns="Market cap data with date, symbol, marketCap.",
+    ),
+    "historical_market_capitalization": FMPEndpoint(
+        name="historical_market_capitalization",
+        function="historical_market_capitalization",
+        description="Historical market capitalization showing company value over time.",
+        category="valuation",
+        parameters={
+            "symbol": {"type": "str", "required": True},
+            "limit": {"type": "int", "required": False, "default": 10},
+            "output": {"type": "str", "required": False, "default": "markdown"},
+        },
+        example_use_cases=[
+            "Market cap growth analysis",
+            "Historical size tracking",
+        ],
+        returns="Historical market cap data.",
+    ),
+    # =========================================================================
+    # RATINGS & ANALYSTS
+    # =========================================================================
+    "rating": FMPEndpoint(
+        name="rating",
+        function="rating",
+        description="FMP's proprietary rating based on financial analysis including DCF, ratios, and intrinsic value.",
+        category="analysts",
+        parameters={
+            "symbol": {"type": "str", "required": True},
+            "output": {"type": "str", "required": False, "default": "markdown"},
+        },
+        example_use_cases=[
+            "Quick investment rating lookup",
+            "Automated screening based on ratings",
+        ],
+        returns="Rating data with symbol, date, rating, ratingScore, ratingRecommendation, etc.",
+    ),
+    "historical_rating": FMPEndpoint(
+        name="historical_rating",
+        function="historical_rating",
+        description="Historical ratings showing how FMP's assessment has changed over time.",
+        category="analysts",
+        parameters={
+            "symbol": {"type": "str", "required": True},
+            "limit": {"type": "int", "required": False, "default": 100},
+            "output": {"type": "str", "required": False, "default": "markdown"},
+        },
+        example_use_cases=[
+            "Rating trend analysis",
+            "Historical sentiment tracking",
+        ],
+        returns="Historical rating data.",
+    ),
+    "analyst_estimates": FMPEndpoint(
+        name="analyst_estimates",
+        function="analyst_estimates",
+        description="Wall Street analyst estimates for future earnings, revenue, and EPS.",
+        category="analysts",
+        parameters={
+            "symbol": {"type": "str", "required": True},
+            "period": {"type": "str", "required": False, "default": "annual"},
+            "limit": {"type": "int", "required": False, "default": 100},
+            "output": {"type": "str", "required": False, "default": "markdown"},
+        },
+        example_use_cases=[
+            "Forward earnings expectations",
+            "Revenue forecast analysis",
+            "Consensus estimate tracking",
+        ],
+        returns="Analyst estimates with estimatedRevenueAvg, estimatedEpsAvg, numberOfAnalysts, etc.",
+        notes="Estimates are not always accurate - use for guidance only.",
+    ),
+    "analyst_recommendation": FMPEndpoint(
+        name="analyst_recommendation",
+        function="analyst_recommendation",
+        description="Analyst buy/sell/hold recommendations with analyst firm details.",
+        category="analysts",
+        parameters={
+            "symbol": {"type": "str", "required": True},
+            "output": {"type": "str", "required": False, "default": "markdown"},
+        },
+        example_use_cases=[
+            "Analyst sentiment analysis",
+            "Recommendation consensus tracking",
+            "Analyst coverage assessment",
+        ],
+        returns="Analyst recommendations with analystName, analystCompany, recommendationKey, etc.",
+    ),
+    "stock_grade": FMPEndpoint(
+        name="stock_grade",
+        function="stock_grade",
+        description="Stock grades from hedge funds, investment firms, and analysts.",
+        category="analysts",
+        parameters={
+            "symbol": {"type": "str", "required": True},
+            "limit": {"type": "int", "required": False, "default": 50},
+            "output": {"type": "str", "required": False, "default": "markdown"},
+        },
+        example_use_cases=[
+            "Professional investor assessment",
+            "Grade change tracking",
+        ],
+        returns="Stock grades with gradingCompany, newGrade, previousGrade, action, etc.",
+    ),
+    "upgrades_downgrades": FMPEndpoint(
+        name="upgrades_downgrades",
+        function="upgrades_downgrades",
+        description="Stock upgrades and downgrades from analysts.",
+        category="analysts",
+        parameters={
+            "symbol": {"type": "str", "required": True},
+            "output": {"type": "str", "required": False, "default": "markdown"},
+        },
+        example_use_cases=[
+            "Rating change tracking",
+            "Analyst sentiment shifts",
+        ],
+        returns="Upgrade/downgrade data with publishedDate, newGrade, previousGrade, gradingCompany.",
+    ),
+    "upgrades_downgrades_consensus": FMPEndpoint(
+        name="upgrades_downgrades_consensus",
+        function="upgrades_downgrades_consensus",
+        description="Consensus rating across all analysts for a stock.",
+        category="analysts",
+        parameters={
+            "symbol": {"type": "str", "required": True},
+            "output": {"type": "str", "required": False, "default": "markdown"},
+        },
+        example_use_cases=[
+            "Overall analyst sentiment",
+            "Consensus view assessment",
+        ],
+        returns="Consensus data with symbol, strongBuy, buy, hold, sell, strongSell, consensus.",
+    ),
+    "upgrades_downgrades_by_company": FMPEndpoint(
+        name="upgrades_downgrades_by_company",
+        function="upgrades_downgrades_by_company",
+        description="All upgrades and downgrades issued by a specific analyst firm.",
+        category="analysts",
+        parameters={
+            "company": {"type": "str", "required": True, "description": "Analyst firm name (e.g., 'Morgan Stanley')"},
+            "output": {"type": "str", "required": False, "default": "markdown"},
+        },
+        example_use_cases=[
+            "Track specific analyst firm recommendations",
+            "Firm-level research aggregation",
+        ],
+        returns="All ratings from the specified analyst firm.",
+    ),
+    # =========================================================================
+    # PRICE TARGETS
+    # =========================================================================
+    "price_targets": FMPEndpoint(
+        name="price_targets",
+        function="price_targets",
+        description="Analyst price targets for a company's stock.",
+        category="price_targets",
+        parameters={
+            "symbol": {"type": "str", "required": True},
+            "output": {"type": "str", "required": False, "default": "markdown"},
+        },
+        example_use_cases=[
+            "Price target analysis",
+            "Upside/downside potential assessment",
+        ],
+        returns="Price targets with analystName, analystCompany, priceTarget, publishedDate.",
+    ),
+    "price_target_summary": FMPEndpoint(
+        name="price_target_summary",
+        function="price_target_summary",
+        description="Summary of price targets including average, high, low, and number of analysts.",
+        category="price_targets",
+        parameters={
+            "symbol": {"type": "str", "required": True},
+            "output": {"type": "str", "required": False, "default": "markdown"},
+        },
+        example_use_cases=[
+            "Quick price target overview",
+            "Analyst consensus target",
+        ],
+        returns="Summary with lastMonth, lastQuarter, high, low, average, median, numberOfAnalysts.",
+    ),
+    "price_target_consensus": FMPEndpoint(
+        name="price_target_consensus",
+        function="price_target_consensus",
+        description="Consensus price target averaging all analyst targets.",
+        category="price_targets",
+        parameters={
+            "symbol": {"type": "str", "required": True},
+            "output": {"type": "str", "required": False, "default": "markdown"},
+        },
+        example_use_cases=[
+            "Consensus price expectation",
+            "Overall market target",
+        ],
+        returns="Consensus price target data.",
+    ),
+    "price_target_by_analyst_name": FMPEndpoint(
+        name="price_target_by_analyst_name",
+        function="price_target_by_analyst_name",
+        description="Price targets from a specific analyst across different stocks.",
+        category="price_targets",
+        parameters={
+            "name": {"type": "str", "required": True, "description": "Analyst name"},
+            "output": {"type": "str", "required": False, "default": "markdown"},
+        },
+        example_use_cases=[
+            "Track specific analyst coverage",
+            "Analyst performance tracking",
+        ],
+        returns="Price targets from the specified analyst.",
+    ),
+    "price_target_by_company": FMPEndpoint(
+        name="price_target_by_company",
+        function="price_target_by_company",
+        description="Price targets from a specific analyst firm.",
+        category="price_targets",
+        parameters={
+            "company": {"type": "str", "required": True, "description": "Analyst firm (e.g., 'Barclays')"},
+            "output": {"type": "str", "required": False, "default": "markdown"},
+        },
+        example_use_cases=[
+            "Firm-level price targets",
+            "Institutional research tracking",
+        ],
+        returns="Price targets from the specified firm.",
+    ),
+    "price_target_rss_feed": FMPEndpoint(
+        name="price_target_rss_feed",
+        function="price_target_rss_feed",
+        description="RSS feed of latest price target updates across all stocks.",
+        category="price_targets",
+        parameters={
+            "page": {"type": "int", "required": False, "default": 0},
+            "output": {"type": "str", "required": False, "default": "markdown"},
+        },
+        example_use_cases=[
+            "Real-time price target monitoring",
+            "Latest analyst actions",
+        ],
+        returns="Recent price target updates.",
+    ),
+    # =========================================================================
+    # ESG
+    # =========================================================================
+    "esg_score": FMPEndpoint(
+        name="esg_score",
+        function="esg_score",
+        description="Environmental, Social, and Governance (ESG) scores with breakdown by E, S, and G components.",
+        category="esg",
+        parameters={
+            "symbol": {"type": "str", "required": True},
+            "output": {"type": "str", "required": False, "default": "markdown"},
+        },
+        example_use_cases=[
+            "Sustainability analysis",
+            "ESG screening",
+            "Socially responsible investing research",
+            "Renewable energy company assessment",
+        ],
+        returns="ESG data with environmentalScore, socialScore, governanceScore, ESGScore, etc.",
+    ),
+    # =========================================================================
+    # COMPANY VALUATION EXTRAS
+    # =========================================================================
+    "stock_peers": FMPEndpoint(
+        name="stock_peers",
+        function="stock_peers",
+        description="Similar companies trading on the same exchange, in the same sector, with similar market cap.",
+        category="company",
+        parameters={
+            "symbol": {"type": "str", "required": True},
+            "output": {"type": "str", "required": False, "default": "markdown"},
+        },
+        example_use_cases=[
+            "Competitor identification",
+            "Peer comparison analysis",
+            "Industry benchmarking",
+        ],
+        returns="List of peer symbols.",
+    ),
+    "financial_score": FMPEndpoint(
+        name="financial_score",
+        function="financial_score",
+        description="Financial health score assessing company performance.",
+        category="metrics",
+        parameters={
+            "symbol": {"type": "str", "required": True},
+            "output": {"type": "str", "required": False, "default": "markdown"},
+        },
+        example_use_cases=[
+            "Financial health assessment",
+            "Quick screening metric",
+        ],
+        returns="Financial score data.",
+    ),
+    "owner_earnings": FMPEndpoint(
+        name="owner_earnings",
+        function="owner_earnings",
+        description="Owner earnings calculation (Buffett's preferred metric) showing true cash available to shareholders.",
+        category="metrics",
+        parameters={
+            "symbol": {"type": "str", "required": True},
+            "output": {"type": "str", "required": False, "default": "markdown"},
+        },
+        example_use_cases=[
+            "Value investing analysis",
+            "True earnings power assessment",
+        ],
+        returns="Owner earnings data.",
+    ),
+    # =========================================================================
+    # SEGMENTS
+    # =========================================================================
+    "sales_revenue_by_segments": FMPEndpoint(
+        name="sales_revenue_by_segments",
+        function="sales_revenue_by_segments",
+        description="Revenue breakdown by business segments (product lines, services, etc.).",
+        category="segments",
+        parameters={
+            "symbol": {"type": "str", "required": True},
+            "period": {"type": "str", "required": False, "default": "quarter"},
+            "limit": {"type": "int", "required": False, "default": None},
+            "output": {"type": "str", "required": False, "default": "markdown"},
+        },
+        example_use_cases=[
+            "Business segment analysis",
+            "Product line performance tracking",
+            "Diversification assessment",
+        ],
+        returns="Revenue by segment with date and segment-specific revenue values.",
+    ),
+    "revenue_geographic_segmentation": FMPEndpoint(
+        name="revenue_geographic_segmentation",
+        function="revenue_geographic_segmentation",
+        description="Revenue breakdown by geographic region showing global market presence.",
+        category="segments",
+        parameters={
+            "symbol": {"type": "str", "required": True},
+            "period": {"type": "str", "required": False, "default": "quarter"},
+            "output": {"type": "str", "required": False, "default": "markdown"},
+        },
+        example_use_cases=[
+            "Geographic exposure analysis",
+            "International expansion tracking",
+            "Regional performance comparison",
+        ],
+        returns="Revenue by geography with date and region-specific revenue values.",
+    ),
+    # =========================================================================
+    # EMPLOYEE & COMPENSATION
+    # =========================================================================
+    "employee_count": FMPEndpoint(
+        name="employee_count",
+        function="employee_count",
+        description="Current number of employees at a company.",
+        category="company",
+        parameters={
+            "symbol": {"type": "str", "required": True},
+            "output": {"type": "str", "required": False, "default": "markdown"},
+        },
+        example_use_cases=[
+            "Company size assessment",
+            "Workforce analysis",
+        ],
+        returns="Employee count data.",
+    ),
+    "historical_employee_count": FMPEndpoint(
+        name="historical_employee_count",
+        function="historical_employee_count",
+        description="Historical employee count showing workforce growth or decline over time.",
+        category="company",
+        parameters={
+            "symbol": {"type": "str", "required": True},
+            "output": {"type": "str", "required": False, "default": "markdown"},
+        },
+        example_use_cases=[
+            "Workforce growth analysis",
+            "Operational scaling assessment",
+        ],
+        returns="Historical employee count data.",
+    ),
+    "executive_compensation": FMPEndpoint(
+        name="executive_compensation",
+        function="executive_compensation",
+        description="Executive compensation data from proxy filings.",
+        category="company",
+        parameters={
+            "symbol": {"type": "str", "required": True},
+            "output": {"type": "str", "required": False, "default": "markdown"},
+        },
+        example_use_cases=[
+            "Executive pay analysis",
+            "Compensation benchmarking",
+            "Corporate governance assessment",
+        ],
+        returns="Executive compensation with name, title, salary, bonus, stockAwards, etc.",
+    ),
+    "compensation_benchmark": FMPEndpoint(
+        name="compensation_benchmark",
+        function="compensation_benchmark",
+        description="Executive compensation benchmarks for a specific year.",
+        category="company",
+        parameters={
+            "year": {"type": "int", "required": True},
+            "output": {"type": "str", "required": False, "default": "markdown"},
+        },
+        example_use_cases=[
+            "Industry compensation comparison",
+            "Pay benchmarking",
+        ],
+        returns="Compensation benchmark data.",
+    ),
+    "company_notes": FMPEndpoint(
+        name="company_notes",
+        function="company_notes",
+        description="Company notes and additional information.",
+        category="company",
+        parameters={
+            "symbol": {"type": "str", "required": True},
+            "output": {"type": "str", "required": False, "default": "markdown"},
+        },
+        example_use_cases=[
+            "Additional company context",
+            "Notes and observations",
+        ],
+        returns="Company notes data.",
+    ),
+    # =========================================================================
+    # M&A
+    # =========================================================================
+    "search_mergers_acquisitions": FMPEndpoint(
+        name="search_mergers_acquisitions",
+        function="search_mergers_acquisitions",
+        description="Search for M&A deals by company name.",
+        category="corporate_actions",
+        parameters={
+            "name": {"type": "str", "required": True, "description": "Company name to search"},
+            "output": {"type": "str", "required": False, "default": "markdown"},
+        },
+        example_use_cases=[
+            "M&A activity research",
+            "Deal history lookup",
+            "Strategic transaction analysis",
+        ],
+        returns="M&A deal data.",
+    ),
+    "mergers_acquisitions_rss_feed": FMPEndpoint(
+        name="mergers_acquisitions_rss_feed",
+        function="mergers_acquisitions_rss_feed",
+        description="RSS feed of latest M&A news and announcements.",
+        category="news",
+        parameters={
+            "page": {"type": "int", "required": False, "default": 0},
+            "output": {"type": "str", "required": False, "default": "markdown"},
+        },
+        example_use_cases=[
+            "Real-time M&A monitoring",
+            "Deal flow tracking",
+        ],
+        returns="Latest M&A news.",
+    ),
+    # =========================================================================
+    # NEWS
+    # =========================================================================
+    "stock_news": FMPEndpoint(
+        name="stock_news",
+        function="stock_news",
+        description="Stock-specific news articles from various sources.",
+        category="news",
+        parameters={
+            "tickers": {"type": "str or list", "required": False, "description": "Stock symbol(s)"},
+            "limit": {"type": "int", "required": False, "default": 25},
+            "page": {"type": "int", "required": False, "default": 0},
+            "from_date": {"type": "str", "required": False, "description": "YYYY-MM-DD"},
+            "to_date": {"type": "str", "required": False, "description": "YYYY-MM-DD"},
+            "output": {"type": "str", "required": False, "default": "markdown"},
+        },
+        example_use_cases=[
+            "Company-specific news tracking",
+            "Event-driven analysis",
+            "Sentiment research",
+        ],
+        returns="News articles with title, publishedDate, site, url, text snippet.",
+    ),
+    "general_news": FMPEndpoint(
+        name="general_news",
+        function="general_news",
+        description="General financial and market news from various sources.",
+        category="news",
+        parameters={
+            "pages": {"type": "int", "required": False, "default": 20},
+            "output": {"type": "str", "required": False, "default": "markdown"},
+        },
+        example_use_cases=[
+            "Market news overview",
+            "General financial coverage",
+        ],
+        returns="General news articles.",
+    ),
+    "fmp_articles": FMPEndpoint(
+        name="fmp_articles",
+        function="fmp_articles",
+        description="Articles published by Financial Modeling Prep.",
+        category="news",
+        parameters={
+            "page": {"type": "int", "required": False, "default": 0},
+            "size": {"type": "int", "required": False, "default": 25},
+            "output": {"type": "str", "required": False, "default": "markdown"},
+        },
+        example_use_cases=[
+            "FMP analysis and research",
+            "Educational content",
+        ],
+        returns="FMP articles with title, date, content.",
+    ),
+    "press_releases": FMPEndpoint(
+        name="press_releases",
+        function="press_releases",
+        description="Company press releases with official announcements.",
+        category="news",
+        parameters={
+            "symbol": {"type": "str", "required": False, "description": "Stock symbol (optional)"},
+            "limit": {"type": "int", "required": False, "default": 10},
+            "page": {"type": "int", "required": False, "default": 0},
+            "output": {"type": "str", "required": False, "default": "markdown"},
+        },
+        example_use_cases=[
+            "Official company announcements",
+            "Corporate communications tracking",
+            "Event detection",
+        ],
+        returns="Press releases with title, date, text.",
+    ),
+    "upgrades_downgrades_rss_feed": FMPEndpoint(
+        name="upgrades_downgrades_rss_feed",
+        function="upgrades_downgrades_rss_feed",
+        description="RSS feed of latest analyst upgrades and downgrades.",
+        category="news",
+        parameters={
+            "page": {"type": "int", "required": False, "default": 0},
+            "output": {"type": "str", "required": False, "default": "markdown"},
+        },
+        example_use_cases=[
+            "Real-time rating changes",
+            "Analyst action monitoring",
+        ],
+        returns="Latest upgrades/downgrades.",
+    ),
+    # =========================================================================
+    # CALENDAR
+    # =========================================================================
+    "earning_calendar": FMPEndpoint(
+        name="earning_calendar",
+        function="earning_calendar",
+        description="Earnings announcement calendar showing upcoming and past earnings dates.",
+        category="calendar",
+        parameters={
+            "from_date": {"type": "str", "required": False, "description": "YYYY-MM-DD"},
+            "to_date": {"type": "str", "required": False, "description": "YYYY-MM-DD"},
+            "estimate_required": {"type": "bool", "required": False, "default": True},
+            "revenue_minimum": {"type": "float", "required": False, "default": 1000000000},
+            "output": {"type": "str", "required": False, "default": "markdown"},
+        },
+        example_use_cases=[
+            "Earnings season tracking",
+            "Upcoming earnings dates",
+            "Event planning",
+        ],
+        returns="Earnings calendar with date, symbol, eps, epsEstimated, revenue, revenueEstimated.",
+    ),
+    "historical_earning_calendar": FMPEndpoint(
+        name="historical_earning_calendar",
+        function="historical_earning_calendar",
+        description="Historical and upcoming earnings dates for a specific company.",
+        category="calendar",
+        parameters={
+            "symbol": {"type": "str", "required": True},
+            "limit": {"type": "int", "required": False, "default": 10},
+            "output": {"type": "str", "required": False, "default": "markdown"},
+        },
+        example_use_cases=[
+            "Company-specific earnings history",
+            "Earnings pattern analysis",
+        ],
+        returns="Historical earnings calendar data.",
+    ),
+    "dividend_calendar": FMPEndpoint(
+        name="dividend_calendar",
+        function="dividend_calendar",
+        description="Dividend payment calendar showing upcoming dividend dates.",
+        category="calendar",
+        parameters={
+            "from_date": {"type": "str", "required": False, "description": "YYYY-MM-DD"},
+            "to_date": {"type": "str", "required": False, "description": "YYYY-MM-DD (max 3 months)"},
+            "output": {"type": "str", "required": False, "default": "markdown"},
+        },
+        example_use_cases=[
+            "Dividend income planning",
+            "Ex-dividend date tracking",
+        ],
+        returns="Dividend calendar with date, symbol, dividend, recordDate, paymentDate.",
+        notes="Maximum 3-month date range.",
+    ),
+    "ipo_calendar": FMPEndpoint(
+        name="ipo_calendar",
+        function="ipo_calendar",
+        description="IPO calendar showing upcoming and recent initial public offerings.",
+        category="calendar",
+        parameters={
+            "from_date": {"type": "str", "required": False, "description": "YYYY-MM-DD"},
+            "to_date": {"type": "str", "required": False, "description": "YYYY-MM-DD"},
+            "output": {"type": "str", "required": False, "default": "markdown"},
+        },
+        example_use_cases=[
+            "IPO tracking",
+            "New listing research",
+        ],
+        returns="IPO calendar with date, symbol, exchange, name, ipoPrice, priceRange.",
+    ),
+    "stock_split_calendar": FMPEndpoint(
+        name="stock_split_calendar",
+        function="stock_split_calendar",
+        description="Stock split calendar showing upcoming splits.",
+        category="calendar",
+        parameters={
+            "from_date": {"type": "str", "required": False, "description": "YYYY-MM-DD"},
+            "to_date": {"type": "str", "required": False, "description": "YYYY-MM-DD"},
+            "output": {"type": "str", "required": False, "default": "markdown"},
+        },
+        example_use_cases=[
+            "Split event tracking",
+            "Corporate action monitoring",
+        ],
+        returns="Stock split calendar with date, symbol, numerator, denominator.",
+    ),
+    "economic_calendar": FMPEndpoint(
+        name="economic_calendar",
+        function="economic_calendar",
+        description="Economic events calendar with GDP, CPI, employment data releases.",
+        category="calendar",
+        parameters={
+            "from_date": {"type": "str", "required": False, "description": "YYYY-MM-DD"},
+            "to_date": {"type": "str", "required": False, "description": "YYYY-MM-DD"},
+            "output": {"type": "str", "required": False, "default": "markdown"},
+            "impact_filter": {"type": "str or list", "required": False, "default": ["High"], "options": ["Low", "Medium", "High"]},
+            "country_filter": {"type": "str or list", "required": False},
+            "currency_filter": {"type": "str or list", "required": False},
+        },
+        example_use_cases=[
+            "Macro event tracking",
+            "Economic data releases",
+            "Market-moving event planning",
+        ],
+        returns="Economic calendar with date, event, country, actual, previous, estimate, impact.",
+    ),
+    # =========================================================================
+    # QUOTES & MARKET DATA
+    # =========================================================================
+    "quote": FMPEndpoint(
+        name="quote",
+        function="quote",
+        description="Real-time full quote with bid/ask, volume, price, and daily statistics.",
+        category="market",
+        parameters={
+            "symbol": {"type": "str or list", "required": True, "description": "Stock symbol(s)"},
+            "output": {"type": "str", "required": False, "default": "markdown"},
+        },
+        example_use_cases=[
+            "Real-time price lookup",
+            "Current market data",
+            "Trading decisions",
+        ],
+        returns="Full quote with price, change, changesPercentage, dayLow, dayHigh, volume, avgVolume, etc.",
+    ),
+    "quote_short": FMPEndpoint(
+        name="quote_short",
+        function="quote_short",
+        description="Simplified real-time quote with just price, change, and volume.",
+        category="market",
+        parameters={
+            "symbol": {"type": "str", "required": True},
+            "output": {"type": "str", "required": False, "default": "markdown"},
+        },
+        example_use_cases=[
+            "Quick price check",
+            "Simple market snapshot",
+        ],
+        returns="Short quote with symbol, price, volume.",
+    ),
+    "historical_price_full": FMPEndpoint(
+        name="historical_price_full",
+        function="historical_price_full",
+        description="Daily historical OHLCV price data for up to 5 years.",
+        category="market",
+        parameters={
+            "symbol": {"type": "str or list", "required": True},
+            "from_date": {"type": "str", "required": False, "description": "YYYY-MM-DD"},
+            "to_date": {"type": "str", "required": False, "description": "YYYY-MM-DD"},
+            "output": {"type": "str", "required": False, "default": "markdown"},
+        },
+        example_use_cases=[
+            "Historical price analysis",
+            "Trend analysis",
+            "Backtesting",
+            "Chart data",
+        ],
+        returns="Historical prices with date, open, high, low, close, volume, change, changePercent.",
+    ),
+    "historical_chart": FMPEndpoint(
+        name="historical_chart",
+        function="historical_chart",
+        description="Intraday and daily historical price data with various timeframes.",
+        category="market",
+        parameters={
+            "symbol": {"type": "str", "required": True},
+            "timeframe": {"type": "str", "required": True, "options": ["1min", "5min", "15min", "30min", "1hour", "4hour", "1day"]},
+            "from_date": {"type": "str", "required": True, "description": "YYYY-MM-DD"},
+            "to_date": {"type": "str", "required": True, "description": "YYYY-MM-DD"},
+            "output": {"type": "str", "required": False, "default": "markdown"},
+        },
+        example_use_cases=[
+            "Intraday analysis",
+            "Short-term trading",
+            "Technical analysis",
+        ],
+        returns="Historical chart data with date, open, high, low, close, volume.",
+    ),
+    "multiple_company_prices": FMPEndpoint(
+        name="multiple_company_prices",
+        function="multiple_company_prices",
+        description="Real-time prices for multiple companies in a single request.",
+        category="market",
+        parameters={
+            "symbols": {"type": "str or list", "required": True},
+            "output": {"type": "str", "required": False, "default": "markdown"},
+        },
+        example_use_cases=[
+            "Portfolio monitoring",
+            "Batch price lookup",
+            "Watchlist updates",
+        ],
+        returns="Prices for multiple symbols.",
+    ),
+    # =========================================================================
+    # MARKET MOVERS
+    # =========================================================================
+    "actives": FMPEndpoint(
+        name="actives",
+        function="actives",
+        description="Most actively traded stocks by volume.",
+        category="market",
+        parameters={
+            "output": {"type": "str", "required": False, "default": "markdown"},
+        },
+        example_use_cases=[
+            "Market activity monitoring",
+            "High volume stock discovery",
+            "Liquidity analysis",
+        ],
+        returns="Active stocks with symbol, name, change, price, changesPercentage, volume.",
+    ),
+    "gainers": FMPEndpoint(
+        name="gainers",
+        function="gainers",
+        description="Stocks with the biggest gains today.",
+        category="market",
+        parameters={
+            "output": {"type": "str", "required": False, "default": "markdown"},
+        },
+        example_use_cases=[
+            "Daily winners tracking",
+            "Momentum stock discovery",
+        ],
+        returns="Top gaining stocks with symbol, name, change, price, changesPercentage.",
+    ),
+    "losers": FMPEndpoint(
+        name="losers",
+        function="losers",
+        description="Stocks with the biggest losses today.",
+        category="market",
+        parameters={
+            "output": {"type": "str", "required": False, "default": "markdown"},
+        },
+        example_use_cases=[
+            "Daily losers tracking",
+            "Sell-off monitoring",
+            "Potential recovery plays",
+        ],
+        returns="Top losing stocks with symbol, name, change, price, changesPercentage.",
+    ),
+    "sectors_performance": FMPEndpoint(
+        name="sectors_performance",
+        function="sectors_performance",
+        description="Current performance by sector.",
+        category="market",
+        parameters={
+            "limit": {"type": "int", "required": False, "default": 10},
+            "output": {"type": "str", "required": False, "default": "markdown"},
+        },
+        example_use_cases=[
+            "Sector rotation analysis",
+            "Market breadth assessment",
+        ],
+        returns="Sector performance with sector name and changesPercentage.",
+    ),
+    "historical_sectors_performance": FMPEndpoint(
+        name="historical_sectors_performance",
+        function="historical_sectors_performance",
+        description="Historical sector performance over time.",
+        category="market",
+        parameters={
+            "from_date": {"type": "str", "required": True, "description": "YYYY-MM-DD"},
+            "to_date": {"type": "str", "required": True, "description": "YYYY-MM-DD"},
+            "output": {"type": "str", "required": False, "default": "markdown"},
+        },
+        example_use_cases=[
+            "Sector trend analysis",
+            "Historical rotation patterns",
+        ],
+        returns="Historical sector performance data.",
+    ),
+    "market_hours": FMPEndpoint(
+        name="market_hours",
+        function="market_hours",
+        description="Market hours information for exchanges.",
+        category="market",
+        parameters={
+            "output": {"type": "str", "required": False, "default": "markdown"},
+        },
+        example_use_cases=[
+            "Trading schedule lookup",
+            "Market timing",
+        ],
+        returns="Market hours data.",
+    ),
+    "is_market_open": FMPEndpoint(
+        name="is_market_open",
+        function="is_market_open",
+        description="Check if a market/exchange is currently open.",
+        category="market",
+        parameters={
+            "exchange": {"type": "str", "required": False, "default": "NASDAQ"},
+            "output": {"type": "str", "required": False, "default": "markdown"},
+        },
+        example_use_cases=[
+            "Market status check",
+            "Trading availability",
+        ],
+        returns="Market open/closed status.",
+    ),
+    # =========================================================================
+    # INDEXES
+    # =========================================================================
+    "indexes": FMPEndpoint(
+        name="indexes",
+        function="indexes",
+        description="Major market indexes (S&P 500, Dow Jones, NASDAQ, etc.).",
+        category="indexes",
+        parameters={
+            "output": {"type": "str", "required": False, "default": "markdown"},
+        },
+        example_use_cases=[
+            "Market benchmark tracking",
+            "Index performance comparison",
+        ],
+        returns="Index data with symbol, name, price, change, changesPercentage.",
+    ),
+    "sp500_constituent": FMPEndpoint(
+        name="sp500_constituent",
+        function="sp500_constituent",
+        description="Current S&P 500 constituents list.",
+        category="indexes",
+        parameters={
+            "output": {"type": "str", "required": False, "default": "markdown"},
+        },
+        example_use_cases=[
+            "S&P 500 stock list",
+            "Index composition analysis",
+        ],
+        returns="S&P 500 constituents with symbol, name, sector, subSector.",
+    ),
+    "historical_sp500_constituent": FMPEndpoint(
+        name="historical_sp500_constituent",
+        function="historical_sp500_constituent",
+        description="Historical S&P 500 additions and removals.",
+        category="indexes",
+        parameters={
+            "output": {"type": "str", "required": False, "default": "markdown"},
+        },
+        example_use_cases=[
+            "Index changes tracking",
+            "Historical composition",
+        ],
+        returns="Historical S&P 500 changes.",
+    ),
+    "nasdaq_constituent": FMPEndpoint(
+        name="nasdaq_constituent",
+        function="nasdaq_constituent",
+        description="Current NASDAQ 100 constituents list.",
+        category="indexes",
+        parameters={
+            "output": {"type": "str", "required": False, "default": "markdown"},
+        },
+        example_use_cases=[
+            "NASDAQ 100 stock list",
+            "Tech index composition",
+        ],
+        returns="NASDAQ constituents with symbol, name, sector.",
+    ),
+    "historical_nasdaq_constituent": FMPEndpoint(
+        name="historical_nasdaq_constituent",
+        function="historical_nasdaq_constituent",
+        description="Historical NASDAQ additions and removals.",
+        category="indexes",
+        parameters={
+            "output": {"type": "str", "required": False, "default": "markdown"},
+        },
+        example_use_cases=[
+            "NASDAQ changes tracking",
+        ],
+        returns="Historical NASDAQ changes.",
+    ),
+    "dowjones_constituent": FMPEndpoint(
+        name="dowjones_constituent",
+        function="dowjones_constituent",
+        description="Current Dow Jones Industrial Average constituents.",
+        category="indexes",
+        parameters={
+            "output": {"type": "str", "required": False, "default": "markdown"},
+        },
+        example_use_cases=[
+            "DJIA stock list",
+            "Blue chip analysis",
+        ],
+        returns="Dow Jones constituents.",
+    ),
+    "historical_dowjones_constituent": FMPEndpoint(
+        name="historical_dowjones_constituent",
+        function="historical_dowjones_constituent",
+        description="Historical Dow Jones additions and removals.",
+        category="indexes",
+        parameters={
+            "output": {"type": "str", "required": False, "default": "markdown"},
+        },
+        example_use_cases=[
+            "DJIA changes tracking",
+        ],
+        returns="Historical Dow Jones changes.",
+    ),
+    # =========================================================================
+    # INSTITUTIONAL & OWNERSHIP
+    # =========================================================================
+    "institutional_holders": FMPEndpoint(
+        name="institutional_holders",
+        function="institutional_holders",
+        description="Major institutional investors holding a stock.",
+        category="ownership",
+        parameters={
+            "symbol": {"type": "str", "required": True},
+            "output": {"type": "str", "required": False, "default": "markdown"},
+        },
+        example_use_cases=[
+            "Institutional ownership analysis",
+            "Smart money tracking",
+            "Ownership concentration",
+        ],
+        returns="Institutional holders with holder name, shares, dateReported, change, changePercentage.",
+    ),
+    "mutual_fund_holders": FMPEndpoint(
+        name="mutual_fund_holders",
+        function="mutual_fund_holders",
+        description="Mutual funds holding a stock.",
+        category="ownership",
+        parameters={
+            "symbol": {"type": "str", "required": True},
+            "output": {"type": "str", "required": False, "default": "markdown"},
+        },
+        example_use_cases=[
+            "Mutual fund ownership tracking",
+            "Fund flow analysis",
+        ],
+        returns="Mutual fund holders data.",
+    ),
+    "etf_holders": FMPEndpoint(
+        name="etf_holders",
+        function="etf_holders",
+        description="ETFs holding a specific stock.",
+        category="ownership",
+        parameters={
+            "symbol": {"type": "str", "required": True},
+            "output": {"type": "str", "required": False, "default": "markdown"},
+        },
+        example_use_cases=[
+            "ETF exposure analysis",
+            "Passive ownership tracking",
+        ],
+        returns="ETF holders data.",
+    ),
+    "form_13f": FMPEndpoint(
+        name="form_13f",
+        function="form_13f",
+        description="Form 13F filings showing institutional holdings over $100M AUM.",
+        category="ownership",
+        parameters={
+            "cik_id": {"type": "str", "required": True, "description": "CIK of institution"},
+            "date": {"type": "str", "required": False, "description": "YYYY-MM-DD"},
+            "output": {"type": "str", "required": False, "default": "markdown"},
+        },
+        example_use_cases=[
+            "Institutional portfolio analysis",
+            "Hedge fund tracking",
+        ],
+        returns="13F holdings with cusip, symbol, shares, value.",
+    ),
+    # =========================================================================
+    # ETF DATA
+    # =========================================================================
+    "etf_sector_weightings": FMPEndpoint(
+        name="etf_sector_weightings",
+        function="etf_sector_weightings",
+        description="Sector weightings for an ETF.",
+        category="etf",
+        parameters={
+            "symbol": {"type": "str", "required": True, "description": "ETF symbol"},
+            "output": {"type": "str", "required": False, "default": "markdown"},
+        },
+        example_use_cases=[
+            "ETF sector exposure analysis",
+            "Portfolio diversification assessment",
+        ],
+        returns="Sector weightings with sector and weightPercentage.",
+    ),
+    "etf_country_weightings": FMPEndpoint(
+        name="etf_country_weightings",
+        function="etf_country_weightings",
+        description="Country/geographic weightings for an ETF.",
+        category="etf",
+        parameters={
+            "symbol": {"type": "str", "required": True},
+            "output": {"type": "str", "required": False, "default": "markdown"},
+        },
+        example_use_cases=[
+            "Geographic exposure analysis",
+            "International diversification",
+        ],
+        returns="Country weightings data.",
+    ),
+    # =========================================================================
+    # INSIDER TRADING
+    # =========================================================================
+    "insider_trading": FMPEndpoint(
+        name="insider_trading",
+        function="insider_trading",
+        description="Insider trading transactions (Form 4 filings).",
+        category="ownership",
+        parameters={
+            "symbol": {"type": "str", "required": False},
+            "reporting_cik": {"type": "int", "required": False},
+            "company_cik": {"type": "int", "required": False},
+            "limit": {"type": "int", "required": False, "default": 10},
+            "output": {"type": "str", "required": False, "default": "markdown"},
+        },
+        example_use_cases=[
+            "Insider sentiment analysis",
+            "Executive trading patterns",
+            "Insider buying/selling signals",
+        ],
+        returns="Insider trades with reportingName, transactionType, securitiesTransacted, price.",
+        notes="Provide only ONE of: symbol, reporting_cik, or company_cik.",
+    ),
+    "insider_trading_rss_feed": FMPEndpoint(
+        name="insider_trading_rss_feed",
+        function="insider_trading_rss_feed",
+        description="Real-time RSS feed of insider trading activity.",
+        category="ownership",
+        parameters={
+            "limit": {"type": "int", "required": False, "default": 10},
+            "output": {"type": "str", "required": False, "default": "markdown"},
+        },
+        example_use_cases=[
+            "Real-time insider activity monitoring",
+            "Breaking insider trades",
+        ],
+        returns="Latest insider trades.",
+    ),
+    # =========================================================================
+    # SENATE TRADING
+    # =========================================================================
+    "senate_trading_rss": FMPEndpoint(
+        name="senate_trading_rss",
+        function="senate_trading_rss",
+        description="RSS feed of Senate member stock trades.",
+        category="ownership",
+        parameters={
+            "page": {"type": "int", "required": False, "default": 0},
+        },
+        example_use_cases=[
+            "Congressional trading tracking",
+            "Political insider trading",
+        ],
+        returns="Senate trading data.",
+    ),
+    "senate_trading_symbol": FMPEndpoint(
+        name="senate_trading_symbol",
+        function="senate_trading_symbol",
+        description="Senate trades filtered by stock symbol.",
+        category="ownership",
+        parameters={
+            "symbol": {"type": "str", "required": True},
+        },
+        example_use_cases=[
+            "Congressional trades in specific stocks",
+        ],
+        returns="Senate trades for the symbol.",
+    ),
+    "senate_disclosure_rss": FMPEndpoint(
+        name="senate_disclosure_rss",
+        function="senate_disclosure_rss",
+        description="RSS feed of Senate financial disclosures.",
+        category="ownership",
+        parameters={
+            "page": {"type": "int", "required": False, "default": 0},
+        },
+        example_use_cases=[
+            "Senate disclosure monitoring",
+        ],
+        returns="Senate disclosure data.",
+    ),
+    "senate_disclosure_symbol": FMPEndpoint(
+        name="senate_disclosure_symbol",
+        function="senate_disclosure_symbol",
+        description="Senate disclosures filtered by stock symbol.",
+        category="ownership",
+        parameters={
+            "symbol": {"type": "str", "required": True},
+        },
+        example_use_cases=[
+            "Senate holdings in specific stocks",
+        ],
+        returns="Senate disclosures for the symbol.",
+    ),
+    # =========================================================================
+    # DIVIDENDS & SPLITS
+    # =========================================================================
+    "historical_stock_dividend": FMPEndpoint(
+        name="historical_stock_dividend",
+        function="historical_stock_dividend",
+        description="Historical dividend payments for a company.",
+        category="dividends",
+        parameters={
+            "symbol": {"type": "str", "required": True},
+            "output": {"type": "str", "required": False, "default": "markdown"},
+        },
+        example_use_cases=[
+            "Dividend history analysis",
+            "Dividend growth tracking",
+            "Income investing research",
+        ],
+        returns="Historical dividends with date, label, adjDividend, dividend.",
+    ),
+    "historical_stock_split": FMPEndpoint(
+        name="historical_stock_split",
+        function="historical_stock_split",
+        description="Historical stock splits for a company.",
+        category="corporate_actions",
+        parameters={
+            "symbol": {"type": "str", "required": True},
+            "output": {"type": "str", "required": False, "default": "markdown"},
+        },
+        example_use_cases=[
+            "Split history analysis",
+            "Price adjustment research",
+        ],
+        returns="Historical splits with date, label, numerator, denominator.",
+    ),
+    # =========================================================================
+    # SHARES FLOAT
+    # =========================================================================
+    "shares_float": FMPEndpoint(
+        name="shares_float",
+        function="shares_float",
+        description="Shares float - publicly traded shares available for trading.",
+        category="market",
+        parameters={
+            "symbol": {"type": "str", "required": True},
+            "all": {"type": "bool", "required": False, "default": False},
+            "output": {"type": "str", "required": False, "default": "markdown"},
+        },
+        example_use_cases=[
+            "Float analysis",
+            "Short squeeze potential",
+            "Liquidity assessment",
+        ],
+        returns="Shares float with symbol, date, freeFloat, floatShares, outstandingShares.",
+    ),
+    "historical_share_float": FMPEndpoint(
+        name="historical_share_float",
+        function="historical_share_float",
+        description="Historical shares float data over time.",
+        category="market",
+        parameters={
+            "symbol": {"type": "str", "required": True},
+            "output": {"type": "str", "required": False, "default": "markdown"},
+        },
+        example_use_cases=[
+            "Float changes over time",
+            "Dilution tracking",
+        ],
+        returns="Historical float data.",
+    ),
+    # =========================================================================
+    # SOCIAL SENTIMENT
+    # =========================================================================
+    "historical_social_sentiment": FMPEndpoint(
+        name="historical_social_sentiment",
+        function="historical_social_sentiment",
+        description="Historical social media sentiment for a stock.",
+        category="sentiment",
+        parameters={
+            "symbol": {"type": "str", "required": True},
+            "page": {"type": "int", "required": False, "default": 0},
+            "output": {"type": "str", "required": False, "default": "markdown"},
+        },
+        example_use_cases=[
+            "Social sentiment trends",
+            "Retail investor sentiment",
+        ],
+        returns="Social sentiment data with date and sentiment metrics.",
+    ),
+    "trending_social_sentiment": FMPEndpoint(
+        name="trending_social_sentiment",
+        function="trending_social_sentiment",
+        description="Currently trending stocks by social sentiment.",
+        category="sentiment",
+        parameters={
+            "sentiment_type": {"type": "str", "required": False, "default": "bullish", "options": ["bullish", "bearish"]},
+            "source": {"type": "str", "required": False, "default": "stocktwits", "options": ["stocktwits", "twitter"]},
+            "output": {"type": "str", "required": False, "default": "markdown"},
+        },
+        example_use_cases=[
+            "Trending stock discovery",
+            "Social momentum tracking",
+        ],
+        returns="Trending stocks by sentiment.",
+    ),
+    "social_sentiment_changes": FMPEndpoint(
+        name="social_sentiment_changes",
+        function="social_sentiment_changes",
+        description="Changes in social sentiment over time.",
+        category="sentiment",
+        parameters={
+            "sentiment_type": {"type": "str", "required": False, "default": "bullish"},
+            "source": {"type": "str", "required": False, "default": "stocktwits"},
+            "output": {"type": "str", "required": False, "default": "markdown"},
+        },
+        example_use_cases=[
+            "Sentiment shift detection",
+            "Momentum changes",
+        ],
+        returns="Sentiment change data.",
+    ),
+    # =========================================================================
+    # TECHNICAL INDICATORS
+    # =========================================================================
+    "technical_indicators": FMPEndpoint(
+        name="technical_indicators",
+        function="technical_indicators",
+        description="Technical indicators (SMA, EMA, RSI, MACD, etc.).",
+        category="technical",
+        parameters={
+            "symbol": {"type": "str", "required": True},
+            "period": {"type": "int", "required": False, "default": 10},
+            "statistics_type": {"type": "str", "required": False, "default": "sma", "options": ["sma", "ema", "wma", "dema", "tema", "williams", "rsi", "adx", "standardDeviation"]},
+            "time_delta": {"type": "str", "required": False, "default": "1day", "options": ["1min", "5min", "15min", "30min", "1hour", "4hour", "1day"]},
+            "output": {"type": "str", "required": False, "default": "markdown"},
+        },
+        example_use_cases=[
+            "Technical analysis",
+            "Trading signals",
+            "Trend identification",
+        ],
+        returns="Technical indicator values with date and indicator value.",
+    ),
+    # =========================================================================
+    # ECONOMICS
+    # =========================================================================
+    "treasury_rates": FMPEndpoint(
+        name="treasury_rates",
+        function="treasury_rates",
+        description="US Treasury rates across all maturities.",
+        category="economics",
+        parameters={
+            "from_date": {"type": "str", "required": False},
+            "to_date": {"type": "str", "required": False},
+            "output": {"type": "str", "required": False, "default": "markdown"},
+        },
+        example_use_cases=[
+            "Interest rate analysis",
+            "Yield curve research",
+            "Risk-free rate lookup",
+        ],
+        returns="Treasury rates with date and rates for various maturities.",
+    ),
+    "economic_indicators": FMPEndpoint(
+        name="economic_indicators",
+        function="economic_indicators",
+        description="Economic indicators (GDP, CPI, unemployment, etc.).",
+        category="economics",
+        parameters={
+            "name": {"type": "str", "required": True, "description": "Indicator name (GDP, CPI, unemploymentRate, etc.)"},
+            "from_date": {"type": "str", "required": False},
+            "to_date": {"type": "str", "required": False},
+            "output": {"type": "str", "required": False, "default": "markdown"},
+        },
+        example_use_cases=[
+            "Macro economic analysis",
+            "GDP tracking",
+            "Inflation monitoring",
+        ],
+        returns="Economic indicator values with date and value.",
+    ),
+    "market_risk_premium": FMPEndpoint(
+        name="market_risk_premium",
+        function="market_risk_premium",
+        description="Market risk premium by country for CAPM calculations.",
+        category="economics",
+        parameters={
+            "country": {"type": "str", "required": False},
+            "output": {"type": "str", "required": False, "default": "markdown"},
+        },
+        example_use_cases=[
+            "CAPM calculations",
+            "Cost of equity estimation",
+        ],
+        returns="Market risk premium data.",
+    ),
+    # =========================================================================
+    # FOREX
+    # =========================================================================
+    "forex": FMPEndpoint(
+        name="forex",
+        function="forex",
+        description="Real-time forex prices for all currency pairs.",
+        category="forex",
+        parameters={
+            "output": {"type": "str", "required": False, "default": "markdown"},
+        },
+        example_use_cases=[
+            "Currency rate lookup",
+            "FX market overview",
+        ],
+        returns="Forex prices with ticker, bid, ask, changes.",
+    ),
+    "forex_list": FMPEndpoint(
+        name="forex_list",
+        function="forex_list",
+        description="Full quote list for all forex currency pairs.",
+        category="forex",
+        parameters={
+            "output": {"type": "str", "required": False, "default": "markdown"},
+        },
+        example_use_cases=[
+            "Complete FX market data",
+        ],
+        returns="Full forex quotes.",
+    ),
+    "forex_quote": FMPEndpoint(
+        name="forex_quote",
+        function="forex_quote",
+        description="Full quote for a specific forex pair.",
+        category="forex",
+        parameters={
+            "symbol": {"type": "str", "required": True, "description": "Currency pair (e.g., 'EURUSD')"},
+            "output": {"type": "str", "required": False, "default": "markdown"},
+        },
+        example_use_cases=[
+            "Specific currency pair quote",
+        ],
+        returns="Forex quote data.",
+    ),
+    "forex_historical": FMPEndpoint(
+        name="forex_historical",
+        function="forex_historical",
+        description="Historical forex data for a currency pair.",
+        category="forex",
+        parameters={
+            "symbol": {"type": "str", "required": True},
+            "from_date": {"type": "str", "required": True},
+            "to_date": {"type": "str", "required": True},
+            "output": {"type": "str", "required": False, "default": "markdown"},
+        },
+        example_use_cases=[
+            "Historical FX analysis",
+            "Currency trend research",
+        ],
+        returns="Historical forex prices.",
+    ),
+    # =========================================================================
+    # CRYPTO
+    # =========================================================================
+    "cryptocurrency_quote": FMPEndpoint(
+        name="cryptocurrency_quote",
+        function="cryptocurrency_quote",
+        description="Real-time cryptocurrency quote.",
+        category="crypto",
+        parameters={
+            "symbol": {"type": "str", "required": True, "description": "Crypto pair (e.g., 'BTCUSD')"},
+            "output": {"type": "str", "required": False, "default": "markdown"},
+        },
+        example_use_cases=[
+            "Crypto price lookup",
+            "Bitcoin/Ethereum quotes",
+        ],
+        returns="Cryptocurrency quote data.",
+    ),
+    "cryptocurrencies_list": FMPEndpoint(
+        name="cryptocurrencies_list",
+        function="cryptocurrencies_list",
+        description="Full quotes for all cryptocurrencies.",
+        category="crypto",
+        parameters={
+            "output": {"type": "str", "required": False, "default": "markdown"},
+        },
+        example_use_cases=[
+            "Full crypto market overview",
+        ],
+        returns="All cryptocurrency quotes.",
+    ),
+    # =========================================================================
+    # COMMODITIES
+    # =========================================================================
+    "commodity_price": FMPEndpoint(
+        name="commodity_price",
+        function="commodity_price",
+        description="Historical commodity price data.",
+        category="commodities",
+        parameters={
+            "symbol": {"type": "str", "required": True, "description": "Commodity symbol (e.g., 'ZGUSD')"},
+            "from_date": {"type": "str", "required": False},
+            "to_date": {"type": "str", "required": False},
+            "output": {"type": "str", "required": False, "default": "markdown"},
+        },
+        example_use_cases=[
+            "Commodity price analysis",
+            "Gold/oil/silver prices",
+        ],
+        returns="Commodity price data.",
+    ),
+    "commodities_list": FMPEndpoint(
+        name="commodities_list",
+        function="commodities_list",
+        description="Full quotes for all commodities.",
+        category="commodities",
+        parameters={
+            "output": {"type": "str", "required": False, "default": "markdown"},
+        },
+        example_use_cases=[
+            "Commodities market overview",
+        ],
+        returns="All commodity quotes.",
+    ),
+    # =========================================================================
+    # STOCK SCREENER
+    # =========================================================================
+    "stock_screener": FMPEndpoint(
+        name="stock_screener",
+        function="stock_screener",
+        description="Screen stocks based on financial criteria (market cap, beta, dividend, etc.).",
+        category="screener",
+        parameters={
+            "market_cap_more_than": {"type": "float", "required": False},
+            "market_cap_lower_than": {"type": "float", "required": False},
+            "beta_more_than": {"type": "float", "required": False},
+            "beta_lower_than": {"type": "float", "required": False},
+            "volume_more_than": {"type": "float", "required": False},
+            "volume_lower_than": {"type": "float", "required": False},
+            "dividend_more_than": {"type": "float", "required": False},
+            "dividend_lower_than": {"type": "float", "required": False},
+            "price_more_than": {"type": "float", "required": False},
+            "price_lower_than": {"type": "float", "required": False},
+            "is_etf": {"type": "bool", "required": False},
+            "is_fund": {"type": "bool", "required": False},
+            "is_actively_trading": {"type": "bool", "required": False},
+            "sector": {"type": "str", "required": False},
+            "industry": {"type": "str", "required": False},
+            "country": {"type": "str", "required": False},
+            "exchange": {"type": "str or list", "required": False},
+            "limit": {"type": "int", "required": False, "default": 10},
+        },
+        example_use_cases=[
+            "Investment screening",
+            "Stock discovery by criteria",
+            "Sector-specific searches",
+        ],
+        returns="Screened stocks with symbol, companyName, marketCap, sector, etc.",
+    ),
+    # =========================================================================
+    # SEARCH
+    # =========================================================================
+    "search": FMPEndpoint(
+        name="search",
+        function="search",
+        description="Search for stocks, ETFs, and financial instruments by name or ticker.",
+        category="search",
+        parameters={
+            "query": {"type": "str", "required": False, "description": "Search query"},
+            "limit": {"type": "int", "required": False, "default": 10},
+            "exchange": {"type": "str", "required": False},
+        },
+        example_use_cases=[
+            "Find stock by name",
+            "Ticker lookup",
+        ],
+        returns="Search results with symbol, name, currency, stockExchange.",
+    ),
+    "search_ticker": FMPEndpoint(
+        name="search_ticker",
+        function="search_ticker",
+        description="Search specifically for ticker symbols.",
+        category="search",
+        parameters={
+            "query": {"type": "str", "required": False},
+            "limit": {"type": "int", "required": False, "default": 10},
+            "exchange": {"type": "str", "required": False},
+        },
+        example_use_cases=[
+            "Ticker symbol lookup",
+        ],
+        returns="Ticker search results.",
+    ),
+    # =========================================================================
+    # REFERENCE DATA
+    # =========================================================================
+    "symbols_list": FMPEndpoint(
+        name="symbols_list",
+        function="symbols_list",
+        description="Full list of all available stock symbols.",
+        category="reference",
+        parameters={
+            "output": {"type": "str", "required": False, "default": "markdown"},
+        },
+        example_use_cases=[
+            "Complete stock universe",
+        ],
+        returns="All stock symbols.",
+    ),
+    "etf_list": FMPEndpoint(
+        name="etf_list",
+        function="etf_list",
+        description="Full list of all available ETFs.",
+        category="reference",
+        parameters={
+            "output": {"type": "str", "required": False, "default": "markdown"},
+        },
+        example_use_cases=[
+            "ETF universe",
+        ],
+        returns="All ETF symbols.",
+    ),
+    "available_traded_list": FMPEndpoint(
+        name="available_traded_list",
+        function="available_traded_list",
+        description="List of all tradable symbols.",
+        category="reference",
+        parameters={},
+        example_use_cases=[
+            "Tradable securities list",
+        ],
+        returns="All tradable symbols.",
+    ),
+    "available_forex": FMPEndpoint(
+        name="available_forex",
+        function="available_forex",
+        description="List of available forex currency pairs.",
+        category="reference",
+        parameters={},
+        example_use_cases=[
+            "FX pair availability",
+        ],
+        returns="Available forex pairs.",
+    ),
+    "available_cryptocurrencies": FMPEndpoint(
+        name="available_cryptocurrencies",
+        function="available_cryptocurrencies",
+        description="List of available cryptocurrencies.",
+        category="reference",
+        parameters={
+            "output": {"type": "str", "required": False, "default": "markdown"},
+        },
+        example_use_cases=[
+            "Crypto availability",
+        ],
+        returns="Available cryptocurrencies.",
+    ),
+    "available_commodities": FMPEndpoint(
+        name="available_commodities",
+        function="available_commodities",
+        description="List of available commodities.",
+        category="reference",
+        parameters={},
+        example_use_cases=[
+            "Commodity availability",
+        ],
+        returns="Available commodities.",
+    ),
+    "available_etfs": FMPEndpoint(
+        name="available_etfs",
+        function="available_etfs",
+        description="List of available ETFs.",
+        category="reference",
+        parameters={},
+        example_use_cases=[
+            "ETF availability",
+        ],
+        returns="Available ETFs.",
+    ),
+    "available_indexes": FMPEndpoint(
+        name="available_indexes",
+        function="available_indexes",
+        description="List of available market indexes.",
+        category="reference",
+        parameters={
+            "output": {"type": "str", "required": False, "default": "markdown"},
+        },
+        example_use_cases=[
+            "Index availability",
+        ],
+        returns="Available indexes.",
+    ),
+    "available_sectors": FMPEndpoint(
+        name="available_sectors",
+        function="available_sectors",
+        description="List of available market sectors.",
+        category="reference",
+        parameters={},
+        example_use_cases=[
+            "Sector list for screening",
+        ],
+        returns="Available sectors.",
+    ),
+    "available_industries": FMPEndpoint(
+        name="available_industries",
+        function="available_industries",
+        description="List of available industries.",
+        category="reference",
+        parameters={},
+        example_use_cases=[
+            "Industry list for screening",
+        ],
+        returns="Available industries.",
+    ),
+    "available_exchanges": FMPEndpoint(
+        name="available_exchanges",
+        function="available_exchanges",
+        description="List of available stock exchanges.",
+        category="reference",
+        parameters={},
+        example_use_cases=[
+            "Exchange list",
+        ],
+        returns="Available exchanges.",
+    ),
+    "all_countries": FMPEndpoint(
+        name="all_countries",
+        function="all_countries",
+        description="List of all countries with market data.",
+        category="reference",
+        parameters={},
+        example_use_cases=[
+            "Country availability",
+        ],
+        returns="All countries.",
+    ),
+    "delisted_companies": FMPEndpoint(
+        name="delisted_companies",
+        function="delisted_companies",
+        description="List of delisted companies.",
+        category="reference",
+        parameters={
+            "limit": {"type": "int", "required": False, "default": 10},
+        },
+        example_use_cases=[
+            "Historical delisting tracking",
+        ],
+        returns="Delisted companies.",
+    ),
+    "financial_statement_symbol_lists": FMPEndpoint(
+        name="financial_statement_symbol_lists",
+        function="financial_statement_symbol_lists",
+        description="Symbols with available financial statements.",
+        category="reference",
+        parameters={
+            "output": {"type": "str", "required": False, "default": "markdown"},
+        },
+        example_use_cases=[
+            "Find companies with financials",
+        ],
+        returns="Symbols with financial statements.",
+    ),
+    # =========================================================================
+    # CIK MAPPING
+    # =========================================================================
+    "cik": FMPEndpoint(
+        name="cik",
+        function="cik",
+        description="Get company name by CIK.",
+        category="reference",
+        parameters={
+            "cik_id": {"type": "str", "required": True},
+            "output": {"type": "str", "required": False, "default": "markdown"},
+        },
+        example_use_cases=[
+            "CIK to company lookup",
+        ],
+        returns="Company name for CIK.",
+    ),
+    "cik_list": FMPEndpoint(
+        name="cik_list",
+        function="cik_list",
+        description="Full list of CIK numbers.",
+        category="reference",
+        parameters={
+            "output": {"type": "str", "required": False, "default": "markdown"},
+        },
+        example_use_cases=[
+            "CIK database",
+        ],
+        returns="CIK list.",
+    ),
+    "cik_search": FMPEndpoint(
+        name="cik_search",
+        function="cik_search",
+        description="Search for CIK by company name.",
+        category="reference",
+        parameters={
+            "name": {"type": "str", "required": True},
+            "output": {"type": "str", "required": False, "default": "markdown"},
+        },
+        example_use_cases=[
+            "Find CIK by name",
+        ],
+        returns="CIK search results.",
+    ),
+    "cusip": FMPEndpoint(
+        name="cusip",
+        function="cusip",
+        description="CUSIP mapper for CIK.",
+        category="reference",
+        parameters={
+            "cik_id": {"type": "str", "required": True},
+            "output": {"type": "str", "required": False, "default": "markdown"},
+        },
+        example_use_cases=[
+            "CUSIP lookup",
+        ],
+        returns="CUSIP data.",
+    ),
+    "mapper_cik_name": FMPEndpoint(
+        name="mapper_cik_name",
+        function="mapper_cik_name",
+        description="Map CIK to insider names.",
+        category="reference",
+        parameters={
+            "name": {"type": "str", "required": True},
+            "output": {"type": "str", "required": False, "default": "markdown"},
+        },
+        example_use_cases=[
+            "Find CIK for insider",
+        ],
+        returns="CIK mapping.",
+    ),
+    "mapper_cik_company": FMPEndpoint(
+        name="mapper_cik_company",
+        function="mapper_cik_company",
+        description="Map ticker to company CIK.",
+        category="reference",
+        parameters={
+            "ticker": {"type": "str", "required": True},
+            "output": {"type": "str", "required": False, "default": "markdown"},
+        },
+        example_use_cases=[
+            "Find CIK for ticker",
+        ],
+        returns="Company CIK.",
+    ),
+    # =========================================================================
+    # ALTERNATIVE DATA
+    # =========================================================================
+    "commitment_of_traders_report_list": FMPEndpoint(
+        name="commitment_of_traders_report_list",
+        function="commitment_of_traders_report_list",
+        description="List of available COT report symbols.",
+        category="alternative",
+        parameters={
+            "output": {"type": "str", "required": False, "default": "markdown"},
+        },
+        example_use_cases=[
+            "COT report availability",
+        ],
+        returns="COT symbols.",
+    ),
+    "commitment_of_traders_report": FMPEndpoint(
+        name="commitment_of_traders_report",
+        function="commitment_of_traders_report",
+        description="CFTC Commitment of Traders report data.",
+        category="alternative",
+        parameters={
+            "symbol": {"type": "str", "required": True},
+            "from_date": {"type": "str", "required": False},
+            "to_date": {"type": "str", "required": False},
+            "output": {"type": "str", "required": False, "default": "markdown"},
+        },
+        example_use_cases=[
+            "Futures positioning analysis",
+            "Speculator vs hedger activity",
+        ],
+        returns="COT report data.",
+    ),
+    "commitment_of_traders_report_analysis": FMPEndpoint(
+        name="commitment_of_traders_report_analysis",
+        function="commitment_of_traders_report_analysis",
+        description="Analysis of COT report data.",
+        category="alternative",
+        parameters={
+            "symbol": {"type": "str", "required": True},
+            "from_date": {"type": "str", "required": True},
+            "to_date": {"type": "str", "required": True},
+            "output": {"type": "str", "required": False, "default": "markdown"},
+        },
+        example_use_cases=[
+            "COT trend analysis",
+        ],
+        returns="COT analysis data.",
+    ),
+    "fail_to_deliver": FMPEndpoint(
+        name="fail_to_deliver",
+        function="fail_to_deliver",
+        description="Fail-to-deliver data showing settlement failures.",
+        category="alternative",
+        parameters={
+            "symbol": {"type": "str", "required": True},
+            "page": {"type": "int", "required": False, "default": 0},
+            "output": {"type": "str", "required": False, "default": "markdown"},
+        },
+        example_use_cases=[
+            "Short selling analysis",
+            "Settlement issues tracking",
+        ],
+        returns="FTD data.",
+    ),
+    "sector_pe_ratio": FMPEndpoint(
+        name="sector_pe_ratio",
+        function="sector_pe_ratio",
+        description="Sector-level P/E ratios.",
+        category="valuation",
+        parameters={
+            "date": {"type": "str", "required": True, "description": "YYYY-MM-DD"},
+            "exchange": {"type": "str", "required": False, "default": "NYSE"},
+            "output": {"type": "str", "required": False, "default": "markdown"},
+        },
+        example_use_cases=[
+            "Sector valuation comparison",
+        ],
+        returns="Sector PE ratios.",
+    ),
+    "industry_pe_ratio": FMPEndpoint(
+        name="industry_pe_ratio",
+        function="industry_pe_ratio",
+        description="Industry-level P/E ratios.",
+        category="valuation",
+        parameters={
+            "date": {"type": "str", "required": True, "description": "YYYY-MM-DD"},
+            "exchange": {"type": "str", "required": False, "default": "NYSE"},
+            "output": {"type": "str", "required": False, "default": "markdown"},
+        },
+        example_use_cases=[
+            "Industry valuation comparison",
+        ],
+        returns="Industry PE ratios.",
+    ),
+    "batch_eod_prices": FMPEndpoint(
+        name="batch_eod_prices",
+        function="batch_eod_prices",
+        description="End of day prices for all stocks on a specific date.",
+        category="market",
+        parameters={
+            "date": {"type": "str", "required": True, "description": "YYYY-MM-DD"},
+            "output": {"type": "str", "required": False, "default": "markdown"},
+        },
+        example_use_cases=[
+            "Historical EOD snapshot",
+            "Bulk price data",
+        ],
+        returns="All EOD prices for the date.",
+    ),
+    "sec_rss_feeds": FMPEndpoint(
+        name="sec_rss_feeds",
+        function="sec_rss_feeds",
+        description="SEC RSS feed of latest filings.",
+        category="sec",
+        parameters={
+            "limit": {"type": "int", "required": False, "default": 10},
+            "output": {"type": "str", "required": False, "default": "markdown"},
+        },
+        example_use_cases=[
+            "Latest SEC filings",
+            "Real-time filing monitoring",
+        ],
+        returns="Latest SEC filings.",
+    ),
+    "exchange_realtime": FMPEndpoint(
+        name="exchange_realtime",
+        function="exchange_realtime",
+        description="Real-time quotes for all stocks on an exchange.",
+        category="market",
+        parameters={
+            "exchange": {"type": "str", "required": True, "description": "Exchange symbol"},
+        },
+        example_use_cases=[
+            "Exchange-wide real-time data",
+        ],
+        returns="Real-time quotes for exchange.",
+    ),
+    # =========================================================================
+    # CROWDFUNDING
+    # =========================================================================
+    "crowdfunding_rss_feed": FMPEndpoint(
+        name="crowdfunding_rss_feed",
+        function="crowdfunding_rss_feed",
+        description="RSS feed of crowdfunding campaigns.",
+        category="alternative",
+        parameters={
+            "page": {"type": "int", "required": False, "default": 0},
+        },
+        example_use_cases=[
+            "Crowdfunding monitoring",
+        ],
+        returns="Crowdfunding campaigns.",
+    ),
+    "crowdfunding_search": FMPEndpoint(
+        name="crowdfunding_search",
+        function="crowdfunding_search",
+        description="Search crowdfunding campaigns by name.",
+        category="alternative",
+        parameters={
+            "name": {"type": "str", "required": True},
+        },
+        example_use_cases=[
+            "Find specific crowdfunding campaigns",
+        ],
+        returns="Matching crowdfunding campaigns.",
+    ),
+    "crowdfunding_by_cik": FMPEndpoint(
+        name="crowdfunding_by_cik",
+        function="crowdfunding_by_cik",
+        description="Crowdfunding campaigns by company CIK.",
+        category="alternative",
+        parameters={
+            "cik": {"type": "str", "required": True},
+        },
+        example_use_cases=[
+            "Company-specific crowdfunding",
+        ],
+        returns="Crowdfunding campaigns for CIK.",
+    ),
+    # Additional reference data
+    "available_mutual_funds": FMPEndpoint(
+        name="available_mutual_funds",
+        function="available_mutual_funds",
+        description="List of available mutual funds.",
+        category="reference",
+        parameters={},
+        example_use_cases=["Mutual fund availability"],
+        returns="Available mutual funds.",
+    ),
+    "available_tsx": FMPEndpoint(
+        name="available_tsx",
+        function="available_tsx",
+        description="List of available TSX symbols.",
+        category="reference",
+        parameters={},
+        example_use_cases=["TSX availability"],
+        returns="Available TSX symbols.",
+    ),
+    "available_euronext": FMPEndpoint(
+        name="available_euronext",
+        function="available_euronext",
+        description="List of available Euronext stocks.",
+        category="reference",
+        parameters={
+            "output": {"type": "str", "required": False, "default": "markdown"},
+        },
+        example_use_cases=["Euronext availability"],
+        returns="Available Euronext stocks.",
+    ),
+    "mutual_fund_list": FMPEndpoint(
+        name="mutual_fund_list",
+        function="mutual_fund_list",
+        description="Full quotes for all mutual funds.",
+        category="market",
+        parameters={
+            "output": {"type": "str", "required": False, "default": "markdown"},
+        },
+        example_use_cases=["Mutual fund quotes"],
+        returns="All mutual fund quotes.",
+    ),
+    "tsx_list": FMPEndpoint(
+        name="tsx_list",
+        function="tsx_list",
+        description="TSX stocks data.",
+        category="market",
+        parameters={},
+        example_use_cases=["TSX market data"],
+        returns="TSX stocks data.",
+    ),
+}
+
+
+# =============================================================================
+# CATEGORY DEFINITIONS
+# =============================================================================
+
+CATEGORIES = {
+    "financials": "Core financial statements (income, balance sheet, cash flow)",
+    "earnings": "Earnings calls, transcripts, and surprises",
+    "sec": "SEC filings and regulatory documents",
+    "company": "Company profile, executives, and corporate information",
+    "metrics": "Key financial metrics and ratios",
+    "growth": "Financial growth metrics",
+    "valuation": "Valuation metrics (DCF, market cap, PE ratios)",
+    "analysts": "Analyst ratings, estimates, and recommendations",
+    "price_targets": "Analyst price targets",
+    "esg": "Environmental, Social, and Governance scores",
+    "segments": "Business and geographic segment data",
+    "corporate_actions": "M&A, splits, and other corporate actions",
+    "news": "News, press releases, and RSS feeds",
+    "calendar": "Earnings, dividend, IPO, and economic calendars",
+    "market": "Real-time market data, quotes, and movers",
+    "indexes": "Market indexes and constituents",
+    "ownership": "Institutional ownership, insider trading, 13F filings",
+    "etf": "ETF-specific data (holdings, weightings)",
+    "dividends": "Dividend history and payments",
+    "sentiment": "Social sentiment data",
+    "technical": "Technical indicators",
+    "economics": "Economic indicators and treasury rates",
+    "forex": "Foreign exchange data",
+    "crypto": "Cryptocurrency data",
+    "commodities": "Commodity prices",
+    "screener": "Stock screening tools",
+    "search": "Search functionality",
+    "reference": "Reference data (symbol lists, exchanges, etc.)",
+    "alternative": "Alternative data (COT, crowdfunding, FTD)",
+}
+
+
+# =============================================================================
+# HELPER FUNCTIONS
+# =============================================================================
+
+
+def get_endpoints_by_category(category: str) -> List[FMPEndpoint]:
+    """Get all endpoints in a specific category.
+
+    Args:
+        category: Category name (e.g., 'financials', 'sec', 'news')
+
+    Returns:
+        List of FMPEndpoint objects in the category
+    """
+    return [ep for ep in FMP_REGISTRY.values() if ep.category == category]
+
+
+def get_all_categories() -> List[str]:
+    """Get all available categories.
+
+    Returns:
+        List of category names
+    """
+    return list(CATEGORIES.keys())
+
+
+def get_registry_for_llm(
+    categories: Optional[List[str]] = None,
+    include_parameters: bool = True,
+    include_use_cases: bool = True,
+) -> str:
+    """Format registry as context for LLM schema generation.
+
+    Groups endpoints by category with descriptions and use cases.
+    Designed to be token-efficient while providing comprehensive information.
+
+    Args:
+        categories: Optional list of categories to include. If None, includes all.
+        include_parameters: Whether to include parameter details
+        include_use_cases: Whether to include example use cases
+
+    Returns:
+        Formatted string suitable for LLM context
+    """
+    lines = ["# AVAILABLE FMP DATA SOURCES", ""]
+
+    # Filter categories if specified
+    cats_to_include = categories if categories else list(CATEGORIES.keys())
+
+    for cat in cats_to_include:
+        if cat not in CATEGORIES:
+            continue
+
+        endpoints = get_endpoints_by_category(cat)
+        if not endpoints:
+            continue
+
+        # Category header
+        lines.append(f"## {cat.upper().replace('_', ' ')}")
+        lines.append(f"_{CATEGORIES[cat]}_")
+        lines.append("")
+
+        for ep in endpoints:
+            # Endpoint name and description
+            lines.append(f"### {ep.name}")
+            lines.append(f"**Function:** `fmpsdk.{ep.function}()`")
+            lines.append(f"**Description:** {ep.description}")
+
+            # Parameters
+            if include_parameters and ep.parameters:
+                params_str = []
+                for param, details in ep.parameters.items():
+                    if isinstance(details, dict):
+                        req = "required" if details.get("required") else "optional"
+                        default = f", default={details.get('default')}" if "default" in details else ""
+                        options = f", options={details.get('options')}" if "options" in details else ""
+                        params_str.append(f"  - `{param}` ({details.get('type', 'any')}, {req}{default}{options})")
+                    else:
+                        params_str.append(f"  - `{param}`: {details}")
+                if params_str:
+                    lines.append("**Parameters:**")
+                    lines.extend(params_str)
+
+            # Use cases
+            if include_use_cases and ep.example_use_cases:
+                lines.append("**Use when:**")
+                for uc in ep.example_use_cases[:3]:  # Limit to 3 use cases
+                    lines.append(f"  - {uc}")
+
+            # Returns
+            lines.append(f"**Returns:** {ep.returns}")
+
+            # Notes
+            if ep.notes:
+                lines.append(f"**Note:** {ep.notes}")
+
+            lines.append("")
+
+    return "\n".join(lines)
+
+
+def get_compact_registry_for_llm() -> str:
+    """Get a compact version of the registry for token-limited contexts.
+
+    Returns:
+        Compact formatted string
+    """
+    lines = ["# FMP DATA SOURCES (Compact)", ""]
+
+    for cat, desc in CATEGORIES.items():
+        endpoints = get_endpoints_by_category(cat)
+        if not endpoints:
+            continue
+
+        lines.append(f"## {cat.upper()}: {desc}")
+        for ep in endpoints:
+            params = ", ".join(ep.parameters.keys()) if ep.parameters else "none"
+            lines.append(f"- **{ep.name}**({params}): {ep.description[:100]}...")
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+def search_endpoints(query: str) -> List[FMPEndpoint]:
+    """Search endpoints by keyword.
+
+    Args:
+        query: Search query
+
+    Returns:
+        List of matching FMPEndpoint objects
+    """
+    query_lower = query.lower()
+    results = []
+
+    for ep in FMP_REGISTRY.values():
+        if (
+            query_lower in ep.name.lower()
+            or query_lower in ep.description.lower()
+            or query_lower in ep.category.lower()
+            or any(query_lower in uc.lower() for uc in ep.example_use_cases)
+        ):
+            results.append(ep)
+
+    return results

--- a/fmpsdk/fmp_registry.py
+++ b/fmpsdk/fmp_registry.py
@@ -1288,6 +1288,7 @@ FMP_REGISTRY: Dict[str, FMPEndpoint] = {
             "timeframe": {"type": "str", "required": True, "options": ["1min", "5min", "15min", "30min", "1hour", "4hour", "1day"]},
             "from_date": {"type": "str", "required": True, "description": "YYYY-MM-DD"},
             "to_date": {"type": "str", "required": True, "description": "YYYY-MM-DD"},
+            "time_series": {"type": "str", "required": False, "default": "line", "description": "Time series parameter"},
             "output": {"type": "str", "required": False, "default": "markdown"},
         },
         example_use_cases=[
@@ -1837,13 +1838,13 @@ FMP_REGISTRY: Dict[str, FMPEndpoint] = {
     "technical_indicators": FMPEndpoint(
         name="technical_indicators",
         function="technical_indicators",
-        description="Technical indicators (SMA, EMA, RSI, MACD, etc.).",
+        description="Technical indicators (SMA, EMA, WMA, DEMA, TEMA, RSI, ADX, Williams %R, Standard Deviation).",
         category="technical",
         parameters={
             "symbol": {"type": "str", "required": True},
             "period": {"type": "int", "required": False, "default": 10},
             "statistics_type": {"type": "str", "required": False, "default": "sma", "options": ["sma", "ema", "wma", "dema", "tema", "williams", "rsi", "adx", "standardDeviation"]},
-            "time_delta": {"type": "str", "required": False, "default": "1day", "options": ["1min", "5min", "15min", "30min", "1hour", "4hour", "1day"]},
+            "time_delta": {"type": "str", "required": False, "default": "1day", "options": ["1min", "5min", "15min", "30min", "1hour", "4hour", "1day", "1week", "1month", "1year"]},
             "output": {"type": "str", "required": False, "default": "markdown"},
         },
         example_use_cases=[

--- a/fmpsdk/fmp_registry.py
+++ b/fmpsdk/fmp_registry.py
@@ -2586,6 +2586,186 @@ FMP_REGISTRY: Dict[str, FMPEndpoint] = {
         example_use_cases=["TSX market data"],
         returns="TSX stocks data.",
     ),
+    # =========================================================================
+    # NEW STABLE API ENDPOINTS
+    # =========================================================================
+    "income_statement_ttm": FMPEndpoint(
+        name="income_statement_ttm",
+        function="income_statement_ttm",
+        description="Trailing twelve months (TTM) income statement data. Aggregates the most recent 12 months of data regardless of fiscal year.",
+        category="financials",
+        parameters={
+            "symbol": {"type": "str", "required": True, "description": "Stock ticker (e.g., 'AAPL')"},
+            "output": {"type": "str", "required": False, "default": "markdown", "options": ["markdown", "json", "tsv"]},
+        },
+        example_use_cases=[
+            "Current profitability analysis without waiting for quarterly reports",
+            "Rolling 12-month revenue trend analysis",
+            "Most recent financial performance snapshot",
+        ],
+        returns="TTM income statement with revenue, expenses, netIncome, etc.",
+    ),
+    "balance_sheet_statement_ttm": FMPEndpoint(
+        name="balance_sheet_statement_ttm",
+        function="balance_sheet_statement_ttm",
+        description="Most recent balance sheet snapshot showing current financial position.",
+        category="financials",
+        parameters={
+            "symbol": {"type": "str", "required": True, "description": "Stock ticker (e.g., 'AAPL')"},
+            "output": {"type": "str", "required": False, "default": "markdown", "options": ["markdown", "json", "tsv"]},
+        },
+        example_use_cases=[
+            "Current asset and liability analysis",
+            "Latest equity position assessment",
+            "Real-time financial health check",
+        ],
+        returns="Current balance sheet with totalAssets, totalLiabilities, totalEquity, etc.",
+    ),
+    "cash_flow_statement_ttm": FMPEndpoint(
+        name="cash_flow_statement_ttm",
+        function="cash_flow_statement_ttm",
+        description="Trailing twelve months (TTM) cash flow statement. Shows rolling 12-month cash generation and usage.",
+        category="financials",
+        parameters={
+            "symbol": {"type": "str", "required": True, "description": "Stock ticker (e.g., 'AAPL')"},
+            "output": {"type": "str", "required": False, "default": "markdown", "options": ["markdown", "json", "tsv"]},
+        },
+        example_use_cases=[
+            "Current free cash flow analysis",
+            "Rolling cash generation trends",
+            "Capital expenditure assessment",
+        ],
+        returns="TTM cash flow statement with operatingCashFlow, investingCashFlow, financingCashFlow, etc.",
+    ),
+    "latest_financial_statements": FMPEndpoint(
+        name="latest_financial_statements",
+        function="latest_financial_statements",
+        description="Paginated list of the most recently filed financial statements across all companies. Useful for monitoring new filings.",
+        category="financials",
+        parameters={
+            "page": {"type": "int", "required": False, "default": 0, "description": "Page number (0-indexed)"},
+            "limit": {"type": "int", "required": False, "default": 250, "description": "Results per page"},
+            "output": {"type": "str", "required": False, "default": "markdown", "options": ["markdown", "json", "tsv"]},
+        },
+        example_use_cases=[
+            "Monitor new SEC filings across the market",
+            "Track recently updated financials",
+            "Find companies with fresh financial data",
+        ],
+        returns="List of recently filed financial statements with company info and filing dates.",
+    ),
+    "earning_call_transcript_latest": FMPEndpoint(
+        name="earning_call_transcript_latest",
+        function="earning_call_transcript_latest",
+        description="Most recent earnings call transcript for a company. Quick access without specifying year/quarter.",
+        category="earnings",
+        parameters={
+            "symbol": {"type": "str", "required": True, "description": "Stock ticker (e.g., 'AAPL')"},
+            "output": {"type": "str", "required": False, "default": "markdown", "options": ["markdown", "json", "tsv"]},
+        },
+        example_use_cases=[
+            "Quick access to latest management commentary",
+            "Recent earnings call analysis",
+            "Current quarter executive discussions",
+        ],
+        returns="Latest earnings call transcript with content and metadata.",
+        notes="Transcripts can be very long (10k+ words). Consider token limits when processing.",
+    ),
+    "ratings_snapshot": FMPEndpoint(
+        name="ratings_snapshot",
+        function="ratings_snapshot",
+        description="Snapshot of analyst ratings showing buy/hold/sell recommendations distribution.",
+        category="analysts",
+        parameters={
+            "symbol": {"type": "str", "required": True, "description": "Stock ticker (e.g., 'AAPL')"},
+            "output": {"type": "str", "required": False, "default": "markdown", "options": ["markdown", "json", "tsv"]},
+        },
+        example_use_cases=[
+            "Quick analyst sentiment overview",
+            "Buy/sell recommendation counts",
+            "Market consensus assessment",
+        ],
+        returns="Rating distribution with strong buy, buy, hold, sell, strong sell counts.",
+    ),
+    "grades_consensus": FMPEndpoint(
+        name="grades_consensus",
+        function="grades_consensus",
+        description="Consensus grade from analyst ratings aggregated into a single recommendation.",
+        category="analysts",
+        parameters={
+            "symbol": {"type": "str", "required": True, "description": "Stock ticker (e.g., 'AAPL')"},
+            "output": {"type": "str", "required": False, "default": "markdown", "options": ["markdown", "json", "tsv"]},
+        },
+        example_use_cases=[
+            "Overall analyst consensus rating",
+            "Aggregated market opinion",
+            "Quick recommendation lookup",
+        ],
+        returns="Consensus grade with overall recommendation and scores.",
+    ),
+    "aftermarket_trade": FMPEndpoint(
+        name="aftermarket_trade",
+        function="aftermarket_trade",
+        description="After-hours trading data including price, volume, and timestamp. Shows extended hours activity.",
+        category="market",
+        parameters={
+            "symbol": {"type": "str", "required": True, "description": "Stock ticker (e.g., 'AAPL')"},
+            "output": {"type": "str", "required": False, "default": "markdown", "options": ["markdown", "json", "tsv"]},
+        },
+        example_use_cases=[
+            "Monitor after-hours price movements",
+            "Track extended hours volume",
+            "Assess overnight market reactions",
+        ],
+        returns="After-hours trade data with price, volume, timestamp.",
+    ),
+    "aftermarket_quote": FMPEndpoint(
+        name="aftermarket_quote",
+        function="aftermarket_quote",
+        description="After-hours quote data including bid/ask prices. Shows extended hours pricing.",
+        category="market",
+        parameters={
+            "symbol": {"type": "str", "required": True, "description": "Stock ticker (e.g., 'AAPL')"},
+            "output": {"type": "str", "required": False, "default": "markdown", "options": ["markdown", "json", "tsv"]},
+        },
+        example_use_cases=[
+            "After-hours bid/ask spread analysis",
+            "Extended hours market sentiment",
+            "Pre-market pricing assessment",
+        ],
+        returns="After-hours quote with bid, ask, and related pricing data.",
+    ),
+    "industry_performance_snapshot": FMPEndpoint(
+        name="industry_performance_snapshot",
+        function="industry_performance_snapshot",
+        description="Current performance metrics for all market industries. Shows which industries are outperforming or underperforming.",
+        category="market",
+        parameters={
+            "output": {"type": "str", "required": False, "default": "markdown", "options": ["markdown", "json", "tsv"]},
+        },
+        example_use_cases=[
+            "Industry sector comparison",
+            "Identify outperforming sectors",
+            "Market rotation analysis",
+        ],
+        returns="Performance data for each industry with change percentages.",
+    ),
+    "holidays_by_exchange": FMPEndpoint(
+        name="holidays_by_exchange",
+        function="holidays_by_exchange",
+        description="Market holidays for a specific exchange. Shows when markets are closed.",
+        category="market",
+        parameters={
+            "exchange": {"type": "str", "required": True, "description": "Exchange name (e.g., 'NASDAQ', 'NYSE')"},
+            "output": {"type": "str", "required": False, "default": "markdown", "options": ["markdown", "json", "tsv"]},
+        },
+        example_use_cases=[
+            "Trading calendar planning",
+            "Market closure schedule",
+            "Holiday schedule lookup",
+        ],
+        returns="List of holiday dates with names for the exchange.",
+    ),
 }
 
 
@@ -2632,22 +2812,28 @@ CATEGORIES = {
 
 
 def get_endpoints_by_category(category: str) -> List[FMPEndpoint]:
-    """Get all endpoints in a specific category.
+    """
+    Get all endpoints in a specific category.
 
-    Args:
-        category: Category name (e.g., 'financials', 'sec', 'news')
+    Retrieves all FMP endpoint definitions that belong to the specified category,
+    useful for filtering endpoints by functional area.
 
-    Returns:
-        List of FMPEndpoint objects in the category
+    :param category: Category name (e.g., 'financials', 'sec', 'news', 'market').
+    :return: List of FMPEndpoint objects matching the category.
+    :example: get_endpoints_by_category('financials')
     """
     return [ep for ep in FMP_REGISTRY.values() if ep.category == category]
 
 
 def get_all_categories() -> List[str]:
-    """Get all available categories.
+    """
+    Get all available endpoint categories.
 
-    Returns:
-        List of category names
+    Returns the list of category names used to organize FMP endpoints.
+    Categories include: financials, earnings, sec, company, metrics, etc.
+
+    :return: List of category name strings.
+    :example: get_all_categories()
     """
     return list(CATEGORIES.keys())
 
@@ -2657,18 +2843,19 @@ def get_registry_for_llm(
     include_parameters: bool = True,
     include_use_cases: bool = True,
 ) -> str:
-    """Format registry as context for LLM schema generation.
+    """
+    Format registry as context for LLM schema generation.
 
-    Groups endpoints by category with descriptions and use cases.
-    Designed to be token-efficient while providing comprehensive information.
+    Groups endpoints by category with descriptions, parameters, and use cases.
+    Designed to be token-efficient while providing comprehensive information
+    for LLM-powered data source selection.
 
-    Args:
-        categories: Optional list of categories to include. If None, includes all.
-        include_parameters: Whether to include parameter details
-        include_use_cases: Whether to include example use cases
-
-    Returns:
-        Formatted string suitable for LLM context
+    :param categories: Optional list of categories to include. If None, includes all.
+    :param include_parameters: Whether to include parameter details. Default True.
+    :param include_use_cases: Whether to include example use cases. Default True.
+    :return: Markdown-formatted string suitable for LLM context.
+    :example: get_registry_for_llm(categories=['financials', 'earnings'])
+    :example: get_registry_for_llm(include_parameters=False)
     """
     lines = ["# AVAILABLE FMP DATA SOURCES", ""]
 
@@ -2728,10 +2915,15 @@ def get_registry_for_llm(
 
 
 def get_compact_registry_for_llm() -> str:
-    """Get a compact version of the registry for token-limited contexts.
+    """
+    Get a compact version of the registry for token-limited contexts.
 
-    Returns:
-        Compact formatted string
+    Returns a condensed view of all endpoints with truncated descriptions,
+    ideal for contexts with limited token budgets while still providing
+    endpoint discovery capabilities.
+
+    :return: Compact markdown-formatted string with abbreviated endpoint info.
+    :example: get_compact_registry_for_llm()
     """
     lines = ["# FMP DATA SOURCES (Compact)", ""]
 
@@ -2750,13 +2942,17 @@ def get_compact_registry_for_llm() -> str:
 
 
 def search_endpoints(query: str) -> List[FMPEndpoint]:
-    """Search endpoints by keyword.
+    """
+    Search endpoints by keyword.
 
-    Args:
-        query: Search query
+    Performs case-insensitive search across endpoint names, descriptions,
+    categories, and use cases. Useful for finding relevant endpoints
+    based on natural language queries.
 
-    Returns:
-        List of matching FMPEndpoint objects
+    :param query: Search query string (e.g., 'income', 'earnings call', 'insider').
+    :return: List of FMPEndpoint objects matching the search query.
+    :example: search_endpoints('income statement')
+    :example: search_endpoints('analyst')
     """
     query_lower = query.lower()
     results = []

--- a/fmpsdk/institutional_fund.py
+++ b/fmpsdk/institutional_fund.py
@@ -130,7 +130,8 @@ def sec_rss_feeds(
     if download:
         query_vars["datatype"] = "csv"  # Only CSV is supported.
         response = requests.get(f"{BASE_URL_v3}{path}", params=query_vars)
-        open(filename, "wb").write(response.content)
+        with open(filename, "wb") as f:
+            f.write(response.content)
         return None
     else:
         query_vars["limit"] = limit

--- a/fmpsdk/market_indexes.py
+++ b/fmpsdk/market_indexes.py
@@ -50,7 +50,8 @@ def sp500_constituent(
     if download:
         query_vars["datatype"] = "csv"  # Only CSV is supported.
         response = requests.get(f"{BASE_URL_v3}{path}", params=query_vars)
-        open(filename, "wb").write(response.content)
+        with open(filename, "wb") as f:
+            f.write(response.content)
         logging.info(f"Saving SP500 Constituents as {filename}.")
         return None
     else:
@@ -87,7 +88,8 @@ def nasdaq_constituent(
     if download:
         query_vars["datatype"] = "csv"  # Only CSV is supported.
         response = requests.get(f"{BASE_URL_v3}{path}", params=query_vars)
-        open(filename, "wb").write(response.content)
+        with open(filename, "wb") as f:
+            f.write(response.content)
         logging.info(f"Saving NASDAQ Constituents as {filename}.")
         return None
     else:
@@ -124,7 +126,8 @@ def dowjones_constituent(
     if download:
         query_vars["datatype"] = "csv"  # Only CSV is supported.
         response = requests.get(f"{BASE_URL_v3}{path}", params=query_vars)
-        open(filename, "wb").write(response.content)
+        with open(filename, "wb") as f:
+            f.write(response.content)
         logging.info(f"Saving DOWJONES Constituents as {filename}.")
         return None
     else:

--- a/fmpsdk/quote.py
+++ b/fmpsdk/quote.py
@@ -1,6 +1,6 @@
 import typing
 import os
-from .url_methods import __return_json_v3, __validate_time_delta
+from .url_methods import __return_json_v3, __return_json_stable, __validate_time_delta
 from .settings import DEFAULT_LIMIT, DEFAULT_LINE_PARAMETER
 from .data_compression import format_output
 
@@ -313,4 +313,47 @@ def forex_historical(
     query_vars = {"apikey": API_KEY, "from": from_date, "to": to_date}
     result = __return_json_v3(path=path, query_vars=query_vars)
     result = result.get("historical", None)
+    return format_output(result, output)
+
+
+def aftermarket_trade(
+    symbol: str,
+    output: str = 'markdown'
+) -> typing.Union[typing.List[typing.Dict], str]:
+    """
+    Retrieve after-hours trading data for a stock.
+
+    Provides real-time after-hours trade data including price, volume,
+    and timestamp. Useful for monitoring price movements outside regular
+    market hours.
+
+    :param symbol: Company ticker (e.g., 'AAPL').
+    :param output: Output format ('tsv', 'json', or 'markdown'). Defaults to 'markdown'.
+    :return: After-hours trade data in the specified format.
+    :example: aftermarket_trade('AAPL')
+    """
+    path = "aftermarket-trade"
+    query_vars = {"apikey": API_KEY, "symbol": symbol}
+    result = __return_json_stable(path=path, query_vars=query_vars)
+    return format_output(result, output)
+
+
+def aftermarket_quote(
+    symbol: str,
+    output: str = 'markdown'
+) -> typing.Union[typing.List[typing.Dict], str]:
+    """
+    Retrieve after-hours quote data for a stock.
+
+    Provides real-time after-hours bid/ask prices and related quote data.
+    Useful for understanding after-hours market sentiment and pricing.
+
+    :param symbol: Company ticker (e.g., 'AAPL').
+    :param output: Output format ('tsv', 'json', or 'markdown'). Defaults to 'markdown'.
+    :return: After-hours quote data in the specified format.
+    :example: aftermarket_quote('AAPL')
+    """
+    path = "aftermarket-quote"
+    query_vars = {"apikey": API_KEY, "symbol": symbol}
+    result = __return_json_stable(path=path, query_vars=query_vars)
     return format_output(result, output)

--- a/fmpsdk/settings.py
+++ b/fmpsdk/settings.py
@@ -2,6 +2,7 @@ import typing
 
 BASE_URL_v3: str = "https://financialmodelingprep.com/api/v3/"
 BASE_URL_v4: str = "https://financialmodelingprep.com/api/v4/"
+BASE_URL_stable: str = "https://financialmodelingprep.com/stable/"
 DEFAULT_LINE_PARAMETER = "line"
 DEFAULT_LIMIT: int = 10
 INDUSTRY_VALUES: typing.List = [

--- a/fmpsdk/stock_market.py
+++ b/fmpsdk/stock_market.py
@@ -1,7 +1,7 @@
 import typing
 import os
 from .settings import DEFAULT_LIMIT
-from .url_methods import __return_json_v3, __return_json_v4
+from .url_methods import __return_json_v3, __return_json_v4, __return_json_stable
 from datetime import date
 from .data_compression import format_output
 
@@ -213,8 +213,8 @@ def multiple_company_prices(
     result = __return_json_v3(path=path, query_vars=query_vars)
     return format_output(result, output)
 
-def historical_sectors_performance(from_date: str, 
-                                   to_date: str, 
+def historical_sectors_performance(from_date: str,
+                                   to_date: str,
                                    output: str = 'markdown') -> typing.Union[typing.List[typing.Dict], str]:
     """
     Retrieve historical performance data for stock market sectors.
@@ -237,4 +237,45 @@ def historical_sectors_performance(from_date: str,
         "to": to_date
     }
     result = __return_json_v3(path=path, query_vars=query_vars)
+    return format_output(result, output)
+
+
+def industry_performance_snapshot(
+    output: str = 'markdown'
+) -> typing.Union[typing.List[typing.Dict], str]:
+    """
+    Retrieve a snapshot of performance for all market industries.
+
+    Provides current performance metrics for each industry sector,
+    including change percentages and other key indicators. Useful for
+    identifying outperforming or underperforming industries.
+
+    :param output: Output format ('tsv', 'json', or 'markdown'). Defaults to 'markdown'.
+    :return: List of dicts or formatted string with industry performance data.
+    :example: industry_performance_snapshot()
+    """
+    path = "industry-performance-snapshot"
+    query_vars = {"apikey": API_KEY}
+    result = __return_json_stable(path=path, query_vars=query_vars)
+    return format_output(result, output)
+
+
+def holidays_by_exchange(
+    exchange: str,
+    output: str = 'markdown'
+) -> typing.Union[typing.List[typing.Dict], str]:
+    """
+    Retrieve market holidays for a specific exchange.
+
+    Provides a list of dates when the exchange is closed for holidays,
+    useful for planning trading activities and understanding market schedules.
+
+    :param exchange: Exchange name (e.g., 'NASDAQ', 'NYSE').
+    :param output: Output format ('tsv', 'json', or 'markdown'). Defaults to 'markdown'.
+    :return: List of dicts or formatted string with holiday dates and names.
+    :example: holidays_by_exchange('NASDAQ')
+    """
+    path = "holidays-by-exchange"
+    query_vars = {"apikey": API_KEY, "exchange": exchange}
+    result = __return_json_stable(path=path, query_vars=query_vars)
     return format_output(result, output)

--- a/fmpsdk/test.ipynb
+++ b/fmpsdk/test.ipynb
@@ -2,6 +2,118 @@
  "cells": [
   {
    "cell_type": "code",
+   "source": "# FMP Registry - Full Registry for LLM (truncated for display)\nfull_registry = fmpsdk.get_registry_for_llm()\nprint(f\"Full registry length: {len(full_registry)} characters\")\nprint(f\"Full registry tokens: {len(enc.encode(full_registry))}\")\nprint(f\"\\nTotal endpoints in registry: {len(fmpsdk.FMP_REGISTRY)}\")",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "source": "# FMP Registry - Compact Registry for LLM\ncompact_registry = fmpsdk.get_compact_registry_for_llm()\nprint(f\"Compact registry length: {len(compact_registry)} characters\")\nprint(f\"Compact registry tokens: {len(enc.encode(compact_registry))}\")\nprint(\"\\nFirst 2000 characters:\")\nprint(compact_registry[:2000])",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "source": "# FMP Registry - Search Endpoints\nsearch_results = fmpsdk.search_endpoints(\"earnings\")\nprint(f\"Found {len(search_results)} endpoints matching 'earnings':\")\nfor ep in search_results[:5]:\n    print(f\"  - {ep.name} ({ep.category}): {ep.description[:50]}...\")",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "source": "# FMP Registry - Get Endpoints by Category\nfinancials_endpoints = fmpsdk.get_endpoints_by_category(\"financials\")\nprint(f\"Financials category has {len(financials_endpoints)} endpoints:\")\nfor ep in financials_endpoints:\n    print(f\"  - {ep.name}: {ep.description[:60]}...\")",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "source": "# FMP Registry - Get All Categories\ncategories = fmpsdk.get_all_categories()\nprint(f\"Total categories: {len(categories)}\")\npprint(categories)",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "source": "# ============================================\n# REGISTRY FUNCTIONS (Added Dec 2025)\n# ============================================",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "source": "# Holidays by Exchange\nholidays = fmpsdk.holidays_by_exchange(\"NASDAQ\")\ndisplay(Markdown(holidays))\nlen(enc.encode(str(holidays)))",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "source": "# Industry Performance Snapshot\nindustry_performance = fmpsdk.industry_performance_snapshot()\ndisplay(Markdown(industry_performance))\nlen(enc.encode(str(industry_performance)))",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "source": "# Aftermarket Quote\naftermarket_quote = fmpsdk.aftermarket_quote(\"AAPL\")\ndisplay(Markdown(aftermarket_quote))\nlen(enc.encode(str(aftermarket_quote)))",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "source": "# Aftermarket Trade\naftermarket_trade = fmpsdk.aftermarket_trade(\"AAPL\")\ndisplay(Markdown(aftermarket_trade))\nlen(enc.encode(str(aftermarket_trade)))",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "source": "# Grades Consensus\ngrades_consensus = fmpsdk.grades_consensus(\"AAPL\")\ndisplay(Markdown(grades_consensus))\nlen(enc.encode(str(grades_consensus)))",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "source": "# Ratings Snapshot\nratings_snapshot = fmpsdk.ratings_snapshot(\"AAPL\")\ndisplay(Markdown(ratings_snapshot))\nlen(enc.encode(str(ratings_snapshot)))",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "source": "# Earning Call Transcript Latest\n# WARNING: This can return large amounts of text\ntranscript_latest = fmpsdk.earning_call_transcript_latest(\"AAPL\")\ndisplay(Markdown(transcript_latest[:2000] if isinstance(transcript_latest, str) else str(transcript_latest)[:2000]))\nlen(enc.encode(str(transcript_latest)))",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "source": "# Latest Financial Statements\nlatest_financials = fmpsdk.latest_financial_statements(\"AAPL\")\ndisplay(Markdown(latest_financials))\nlen(enc.encode(str(latest_financials)))",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "source": "# Cash Flow Statement TTM (Trailing Twelve Months)\ncash_flow_ttm = fmpsdk.cash_flow_statement_ttm(\"AAPL\")\ndisplay(Markdown(cash_flow_ttm))\nlen(enc.encode(str(cash_flow_ttm)))",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "source": "# Balance Sheet Statement TTM (Trailing Twelve Months)\nbalance_sheet_ttm = fmpsdk.balance_sheet_statement_ttm(\"AAPL\")\ndisplay(Markdown(balance_sheet_ttm))\nlen(enc.encode(str(balance_sheet_ttm)))",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
@@ -1944,7 +2056,14 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": "# ============================================\n# NEW ENDPOINTS (Added Dec 2025)\n# ============================================"
+  },
+  {
+   "cell_type": "code",
+   "source": "# Income Statement TTM (Trailing Twelve Months)\nincome_statement_ttm = fmpsdk.income_statement_ttm(\"AAPL\")\ndisplay(Markdown(income_statement_ttm))\nlen(enc.encode(str(income_statement_ttm)))",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
   }
  ],
  "metadata": {

--- a/fmpsdk/url_methods.py
+++ b/fmpsdk/url_methods.py
@@ -1,5 +1,6 @@
 import logging
 import typing
+import os
 
 import requests
 
@@ -13,6 +14,7 @@ from .settings import (
     TIME_DELTA_VALUES,
     BASE_URL_v3,
     BASE_URL_v4,
+    BASE_URL_stable,
 )
 
 CONNECT_TIMEOUT = 5
@@ -23,6 +25,91 @@ logging.getLogger("requests").setLevel(logging.WARNING)
 logging.getLogger("urllib3").setLevel(logging.WARNING)
 
 
+class FMPAPIError(Exception):
+    """Custom exception for FMP API errors with structured information."""
+
+    def __init__(self, message: str, status_code: int = None, url: str = None):
+        self.message = message
+        self.status_code = status_code
+        self.url = url
+        super().__init__(self.message)
+
+    def __str__(self):
+        parts = [self.message]
+        if self.status_code:
+            parts.append(f"Status: {self.status_code}")
+        if self.url:
+            parts.append(f"URL: {self.url}")
+        return " | ".join(parts)
+
+
+def _check_api_key() -> bool:
+    """
+    Verify that FMP_API_KEY environment variable is set.
+
+    :return: True if API key is set, False otherwise.
+    :raises FMPAPIError: If API key is missing.
+    """
+    api_key = os.getenv('FMP_API_KEY')
+    if not api_key:
+        logging.error("FMP_API_KEY environment variable is not set")
+        return False
+    return True
+
+
+def _handle_response(response: requests.Response, url: str) -> typing.Optional[typing.Union[typing.List, typing.Dict]]:
+    """
+    Handle HTTP response with proper status code checking and error handling.
+
+    :param response: requests.Response object
+    :param url: URL that was requested (for error messages)
+    :return: Parsed JSON data or None on error
+    :raises FMPAPIError: For API-specific errors that should be surfaced
+    """
+    # Check for HTTP errors
+    if response.status_code == 401:
+        logging.error(f"API authentication failed (401). Check your FMP_API_KEY. URL: {url}")
+        return None
+    elif response.status_code == 403:
+        logging.error(f"API access forbidden (403). Your plan may not include this endpoint. URL: {url}")
+        return None
+    elif response.status_code == 404:
+        logging.warning(f"Resource not found (404). Symbol or endpoint may not exist. URL: {url}")
+        return None
+    elif response.status_code == 429:
+        logging.error(f"Rate limit exceeded (429). Too many requests. URL: {url}")
+        return None
+    elif response.status_code >= 500:
+        logging.error(f"FMP server error ({response.status_code}). Try again later. URL: {url}")
+        return None
+    elif response.status_code != 200:
+        logging.error(f"Unexpected HTTP status ({response.status_code}). URL: {url}")
+        return None
+
+    # Handle empty responses
+    if len(response.content) == 0:
+        logging.warning("Response appears to have no data. Returning empty List.")
+        return []
+
+    # Parse JSON with error handling
+    try:
+        data = response.json()
+    except requests.exceptions.JSONDecodeError as e:
+        logging.error(f"Failed to parse JSON response: {e}. URL: {url}")
+        return None
+
+    # Check for FMP API error messages in response
+    if isinstance(data, dict):
+        if "Error Message" in data:
+            logging.error(f"FMP API Error: {data['Error Message']}. URL: {url}")
+            return None
+        if len(data.keys()) == 0:
+            logging.warning("Response appears to have no data. Returning empty List.")
+            return []
+
+    return data
+
+
 def __return_json_v3(
     path: str, query_vars: typing.Dict
 ) -> typing.Optional[typing.List]:
@@ -31,41 +118,32 @@ def __return_json_v3(
 
     :param path: Path after TLD of URL
     :param query_vars: Dictionary of query values (after "?" of URL)
-    :return: JSON response
+    :return: JSON response, empty list on no data, or None on error
     """
+    if not _check_api_key():
+        return None
+
     url = f"{BASE_URL_v3}{path}"
-    return_var = None
     try:
         response = requests.get(
             url, params=query_vars, timeout=(CONNECT_TIMEOUT, READ_TIMEOUT)
         )
-        if len(response.content) > 0:
-            return_var = response.json()
-
-        if len(response.content) == 0 or (
-            isinstance(return_var, dict) and len(return_var.keys()) == 0
-        ):
-            logging.warning("Response appears to have no data.  Returning empty List.")
-            return_var = []
+        return _handle_response(response, url)
 
     except requests.Timeout:
         logging.error(f"Connection to {url} timed out.")
     except requests.ConnectionError:
         logging.error(
-            f"Connection to {url} failed:  DNS failure, refused connection or some other connection related "
-            f"issue."
+            f"Connection to {url} failed: DNS failure, refused connection or other connection issue."
         )
     except requests.TooManyRedirects:
         logging.error(
             f"Request to {url} exceeds the maximum number of predefined redirections."
         )
     except Exception as e:
-        logging.error(
-            f"A requests exception has occurred that we have not yet detailed an 'except' clause for.  "
-            f"Error: {e}"
-        )
+        logging.error(f"Unexpected error during request to {url}: {e}")
 
-    return return_var
+    return None
 
 
 def __return_json_v4(
@@ -76,137 +154,184 @@ def __return_json_v4(
 
     :param path: Path after TLD of URL
     :param query_vars: Dictionary of query values (after "?" of URL)
-    :return: JSON response
+    :return: JSON response, empty list on no data, or None on error
     """
+    if not _check_api_key():
+        return None
+
     url = f"{BASE_URL_v4}{path}"
-    return_var = None
     try:
         response = requests.get(
             url, params=query_vars, timeout=(CONNECT_TIMEOUT, READ_TIMEOUT)
         )
-        if len(response.content) > 0:
-            return_var = response.json()
-
-        if len(response.content) == 0 or (
-            isinstance(return_var, dict) and len(return_var.keys()) == 0
-        ):
-            logging.warning("Response appears to have no data.  Returning empty List.")
-            return_var = []
+        return _handle_response(response, url)
 
     except requests.Timeout:
         logging.error(f"Connection to {url} timed out.")
     except requests.ConnectionError:
         logging.error(
-            f"Connection to {url} failed:  DNS failure, refused connection or some other connection related "
-            f"issue."
+            f"Connection to {url} failed: DNS failure, refused connection or other connection issue."
         )
     except requests.TooManyRedirects:
         logging.error(
             f"Request to {url} exceeds the maximum number of predefined redirections."
         )
     except Exception as e:
-        logging.error(
-            f"A requests exception has occurred that we have not yet detailed an 'except' clause for.  "
-            f"Error: {e}"
+        logging.error(f"Unexpected error during request to {url}: {e}")
+
+    return None
+
+
+def __return_json_stable(
+    path: str, query_vars: typing.Dict
+) -> typing.Optional[typing.List]:
+    """
+    Query URL for JSON response for FMP stable API.
+
+    :param path: Path after TLD of URL
+    :param query_vars: Dictionary of query values (after "?" of URL)
+    :return: JSON response, empty list on no data, or None on error
+    """
+    if not _check_api_key():
+        return None
+
+    url = f"{BASE_URL_stable}{path}"
+    try:
+        response = requests.get(
+            url, params=query_vars, timeout=(CONNECT_TIMEOUT, READ_TIMEOUT)
         )
-    return return_var
+        return _handle_response(response, url)
+
+    except requests.Timeout:
+        logging.error(f"Connection to {url} timed out.")
+    except requests.ConnectionError:
+        logging.error(
+            f"Connection to {url} failed: DNS failure, refused connection or other connection issue."
+        )
+    except requests.TooManyRedirects:
+        logging.error(
+            f"Request to {url} exceeds the maximum number of predefined redirections."
+        )
+    except Exception as e:
+        logging.error(f"Unexpected error during request to {url}: {e}")
+
+    return None
 
 
 def __validate_period(value: str) -> str:
     """
     Check to see if passed string is in the list of possible time periods.
+
     :param value: Period name.
-    :return: Passed value or No Return
+    :return: Passed value if valid.
+    :raises ValueError: If value is not a valid period.
     """
     valid_values = PERIOD_VALUES
     if value in valid_values:
         return value
     else:
-        logging.error(f"Invalid period value: {value}.  Valid options: {valid_values}")
+        error_msg = f"Invalid period value: '{value}'. Valid options: {valid_values}"
+        logging.error(error_msg)
+        raise ValueError(error_msg)
 
 
 def __validate_sector(value: str) -> str:
     """
     Check to see if passed string is in the list of possible Sectors.
+
     :param value: Sector name.
-    :return: Passed value or No Return
+    :return: Passed value if valid.
+    :raises ValueError: If value is not a valid sector.
     """
     valid_values = SECTOR_VALUES
     if value in valid_values:
         return value
     else:
-        logging.error(f"Invalid sector value: {value}.  Valid options: {valid_values}")
+        error_msg = f"Invalid sector value: '{value}'. Valid options: {valid_values}"
+        logging.error(error_msg)
+        raise ValueError(error_msg)
 
 
 def __validate_industry(value: str) -> str:
     """
     Check to see if passed string is in the list of possible Industries.
+
     :param value: Industry name.
-    :return: Passed value or No Return
+    :return: Passed value if valid.
+    :raises ValueError: If value is not a valid industry.
     """
     valid_values = INDUSTRY_VALUES
     if value in valid_values:
         return value
     else:
-        logging.error(
-            f"Invalid industry value: {value}.  Valid options: {valid_values}"
-        )
+        error_msg = f"Invalid industry value: '{value}'. Valid options: {valid_values}"
+        logging.error(error_msg)
+        raise ValueError(error_msg)
 
 
 def __validate_time_delta(value: str) -> str:
     """
     Check to see if passed string is in the list of possible Time Deltas.
+
     :param value: Time Delta name.
-    :return: Passed value or No Return
+    :return: Passed value if valid.
+    :raises ValueError: If value is not a valid time delta.
     """
     valid_values = TIME_DELTA_VALUES
     if value in valid_values:
         return value
     else:
-        logging.error(
-            f"Invalid time_delta value: {value}.  Valid options: {valid_values}"
-        )
+        error_msg = f"Invalid time_delta value: '{value}'. Valid options: {valid_values}"
+        logging.error(error_msg)
+        raise ValueError(error_msg)
 
 
 def __validate_series_type(value: str) -> str:
     """
     Check to see if passed string is in the list of possible Series Type.
+
     :param value: Series Type name.
-    :return: Passed value or No Return
+    :return: Passed value if valid.
+    :raises ValueError: If value is not a valid series type.
     """
     valid_values = SERIES_TYPE_VALUES
     if value in valid_values:
         return value
     else:
-        logging.error(
-            f"Invalid series_type value: {value}.  Valid options: {valid_values}"
-        )
+        error_msg = f"Invalid series_type value: '{value}'. Valid options: {valid_values}"
+        logging.error(error_msg)
+        raise ValueError(error_msg)
 
 
 def __validate_statistics_type(value: str) -> str:
     """
     Check to see if passed string is in the list of possible Statistics Type.
+
     :param value: Statistics Type name.
-    :return: Passed value or No Return
+    :return: Passed value if valid.
+    :raises ValueError: If value is not a valid statistics type.
     """
     valid_values = STATISTICS_TYPE_VALUES
     if value in valid_values:
         return value
     else:
-        logging.error(
-            f"Invalid statistics_type value: {value}.  Valid options: {valid_values}"
-        )
+        error_msg = f"Invalid statistics_type value: '{value}'. Valid options: {valid_values}"
+        logging.error(error_msg)
+        raise ValueError(error_msg)
 
 
 def __validate_technical_indicators_time_delta(value: str) -> str:
-    """Exactly like set_time_delta() method but adds 'daily' as an option.
+    """
+    Exactly like set_time_delta() method but for technical indicators.
+
     :param value: Indicators Time Delta name.
-    :return: Passed value or No Return
+    :return: Passed value if valid.
+    :raises ValueError: If value is not a valid technical indicators time delta.
     """
     valid_values = TECHNICAL_INDICATORS_TIME_DELTA_VALUES
     if value in valid_values:
         return value
     else:
-        logging.error(
-            f"Invalid time_delta value: {value}.  Valid options: {valid_values}"
-        )
+        error_msg = f"Invalid time_delta value: '{value}'. Valid options: {valid_values}"
+        logging.error(error_msg)
+        raise ValueError(error_msg)


### PR DESCRIPTION
## Summary
- Add `CLAUDE.md` with comprehensive fmpsdk development guide covering project structure, code patterns, and development guidelines
- Add `.claude/` directory with code review configuration:
  - `agents/code-reviewer.md` - Review rules and patterns specific to fmpsdk
  - `commands/review-staged.md` - Local code review command
  - `commands/fix-review.md` - Auto-fix command for review issues

## Test plan
- [ ] Verify CLAUDE.md renders correctly on GitHub
- [ ] Verify `/review-staged` command works with Claude Code CLI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces Stable API client with improved error handling, adds multiple new endpoints (TTM financials, aftermarket data, ratings, industry/holiday), creates an LLM-friendly endpoint registry, updates exports/formatting, and adds Claude review config and dev guide.
> 
> - **Core/HTTP**:
>   - Add Stable API support (`BASE_URL_stable`, `__return_json_stable`), API key check, structured response handling, and `FMPAPIError` in `url_methods.py`; validators now raise `ValueError`.
>   - Improve markdown table safety in `data_compression.py` (escape pipes/newlines); ensure formatting returns in several functions.
> - **New Endpoints (Stable API)**:
>   - Financials: `income_statement_ttm`, `balance_sheet_statement_ttm`, `cash_flow_statement_ttm`, `latest_financial_statements`, `earning_call_transcript_latest`.
>   - Market: `aftermarket_trade`, `aftermarket_quote`, `industry_performance_snapshot`, `holidays_by_exchange`.
>   - Valuation/Analysts: `ratings_snapshot`, `grades_consensus`.
> - **Exports/Registry**:
>   - Add new functions to `fmpsdk/__init__.py` and export `FMPAPIError`.
>   - Introduce `fmpsdk/fmp_registry.py` with `FMPEndpoint`, `FMP_REGISTRY`, and helpers (`get_*`, `search_endpoints`) for LLM usage.
> - **IO Safety**:
>   - Replace direct `open(...).write(...)` with context managers in file download paths.
> - **Docs/Tooling**:
>   - Add `CLAUDE.md` (dev guide) and `.claude/` review commands/agent (`code-reviewer.md`, `review-staged.md`, `fix-review.md`).
>   - Update `fmpsdk/test.ipynb` with examples for new endpoints and registry.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5561e75045199aa1f5406111d99593f98399d1c9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->